### PR TITLE
fix: MultiKeyring instanceof

### DIFF
--- a/modules/material-management/src/index.ts
+++ b/modules/material-management/src/index.ts
@@ -13,12 +13,6 @@
  * limitations under the License.
  */
 
-import { Keyring } from './keyring'
-import { MultiKeyring } from './multi_keyring'
-import { NodeAlgorithmSuite } from './node_algorithms' // eslint-disable-line no-unused-vars
-import { WebCryptoAlgorithmSuite } from './web_crypto_algorithms' // eslint-disable-line no-unused-vars
-import { immutableClass } from './immutable_class'
-
 export { AlgorithmSuiteIdentifier, AlgorithmSuiteName, AlgorithmSuite } from './algorithm_suites'
 export { AlgorithmSuiteTypeNode, AlgorithmSuiteTypeWebCrypto } from './algorithm_suites'
 export { NodeEncryption, WebCryptoEncryption } from './algorithm_suites'
@@ -29,12 +23,13 @@ export { RawAesWrappingSuiteIdentifier, WrappingSuiteIdentifier } from './algori
 export { WebCryptoAlgorithmSuite } from './web_crypto_algorithms'
 export { NodeAlgorithmSuite } from './node_algorithms'
 
-export { Keyring } from './keyring'
+export { Keyring, KeyringNode, KeyringWebCrypto } from './keyring'
 export { KeyringTrace, KeyringTraceFlag } from './keyring_trace'
-export { MultiKeyring } from './multi_keyring'
+export { MultiKeyringNode, MultiKeyringWebCrypto } from './multi_keyring'
 export { NodeMaterialsManager, WebCryptoMaterialsManager } from './materials_manager'
 
-export { NodeEncryptionMaterial, NodeDecryptionMaterial, isValidCryptoKey, isCryptoKey, keyUsageForMaterial, subtleFunctionForMaterial } from './cryptographic_material'
+export { NodeEncryptionMaterial, NodeDecryptionMaterial } from './cryptographic_material'
+export { isValidCryptoKey, isCryptoKey, keyUsageForMaterial, subtleFunctionForMaterial } from './cryptographic_material'
 export { WebCryptoEncryptionMaterial, WebCryptoDecryptionMaterial } from './cryptographic_material'
 export { isEncryptionMaterial, isDecryptionMaterial } from './cryptographic_material'
 export { SignatureKey, VerificationKey } from './signature_key'
@@ -45,12 +40,3 @@ export { immutableBaseClass, immutableClass, frozenClass, readOnlyProperty } fro
 export { needs } from './needs'
 
 export * from './types'
-
-export abstract class KeyringNode extends Keyring<NodeAlgorithmSuite> {}
-immutableClass(KeyringNode)
-export class MultiKeyringNode extends MultiKeyring<NodeAlgorithmSuite> {}
-immutableClass(MultiKeyringNode)
-export abstract class KeyringWebCrypto extends Keyring<WebCryptoAlgorithmSuite> {}
-immutableClass(KeyringWebCrypto)
-export class MultiKeyringWebCrypto extends MultiKeyring<WebCryptoAlgorithmSuite> {}
-immutableClass(MultiKeyringWebCrypto)

--- a/modules/material-management/src/keyring.ts
+++ b/modules/material-management/src/keyring.ts
@@ -14,11 +14,13 @@
  */
 
 import { EncryptedDataKey } from './encrypted_data_key'
-import { immutableBaseClass } from './immutable_class'
+import { immutableBaseClass, immutableClass } from './immutable_class'
 
 import { isEncryptionMaterial, isDecryptionMaterial } from './cryptographic_material'
 import { EncryptionContext, EncryptionMaterial, DecryptionMaterial, SupportedAlgorithmSuites } from './types' // eslint-disable-line no-unused-vars
 import { needs } from './needs'
+import { NodeAlgorithmSuite } from './node_algorithms' // eslint-disable-line no-unused-vars
+import { WebCryptoAlgorithmSuite } from './web_crypto_algorithms' // eslint-disable-line no-unused-vars
 
 /*
  * This public interface to the Keyring object is provided for
@@ -103,3 +105,8 @@ export abstract class Keyring<S extends SupportedAlgorithmSuites> {
 }
 
 immutableBaseClass(Keyring)
+
+export abstract class KeyringNode extends Keyring<NodeAlgorithmSuite> {}
+immutableClass(KeyringNode)
+export abstract class KeyringWebCrypto extends Keyring<WebCryptoAlgorithmSuite> {}
+immutableClass(KeyringWebCrypto)

--- a/modules/material-management/src/multi_keyring.ts
+++ b/modules/material-management/src/multi_keyring.ts
@@ -14,76 +14,102 @@
  */
 
 import { immutableClass, readOnlyProperty } from './immutable_class'
-import { Keyring } from './keyring'
-import { EncryptionContext, EncryptionMaterial, DecryptionMaterial, SupportedAlgorithmSuites } from './types' // eslint-disable-line no-unused-vars
+import {
+  Keyring, // eslint-disable-line no-unused-vars
+  KeyringNode,
+  KeyringWebCrypto
+} from './keyring'
+import { EncryptionContext, SupportedAlgorithmSuites, EncryptionMaterial, DecryptionMaterial } from './types' // eslint-disable-line no-unused-vars
 import { needs } from './needs'
 import { EncryptedDataKey } from './encrypted_data_key' // eslint-disable-line no-unused-vars
+import { NodeAlgorithmSuite } from './node_algorithms' // eslint-disable-line no-unused-vars
+import { WebCryptoAlgorithmSuite } from './web_crypto_algorithms' // eslint-disable-line no-unused-vars
 
-export interface MultiKeyringInput<S extends SupportedAlgorithmSuites> {
+export const MultiKeyringNode = buildMultiKeyring(KeyringNode as KeyRingConstructible<NodeAlgorithmSuite>)
+export const MultiKeyringWebCrypto = buildMultiKeyring(KeyringWebCrypto as KeyRingConstructible<WebCryptoAlgorithmSuite>)
+
+function buildMultiKeyring<S extends SupportedAlgorithmSuites> (BaseKeyring: KeyRingConstructible<S>): MultiKeyringConstructible<S> {
+  class MultiKeyring extends BaseKeyring {
+    public readonly generator?: Keyring<S>
+    public readonly children!: ReadonlyArray<Keyring<S>>
+    constructor ({ generator, children = [] }: MultiKeyringInput<S>) {
+      super()
+      /* Precondition: MultiKeyring must have keyrings. */
+      needs(generator || children.length, 'Noop MultiKeyring is not supported.')
+      /* Precondition: generator must be a Keyring. */
+      needs(!!generator === generator instanceof BaseKeyring, 'Generator must be a Keyring')
+      /* Precondition: All children must be Keyrings. */
+      needs(children.every(kr => kr instanceof BaseKeyring), 'Child must be a Keyring')
+
+      readOnlyProperty(this, 'children', Object.freeze(children.slice()))
+      readOnlyProperty(this, 'generator', generator)
+    }
+
+    async _onEncrypt (material: EncryptionMaterial<S>, context?: EncryptionContext) {
+      const generated = this.generator
+        ? await this.generator.onEncrypt(material, context)
+        : material
+
+      /* Precondition: A Generator Keyring *must* ensure generated material. */
+      needs(this.generator && generated.hasUnencryptedDataKey, 'Generator Keyring has not generated material.')
+      /* Precondition: Only Keyrings explicitly designated as generators can generate material. */
+      needs(generated.hasUnencryptedDataKey, 'Only Keyrings explicitly designated as generators can generate material.')
+
+      /* By default this is a serial operation.  A keyring _may_ perform an expensive operation
+      * or create resource constraints such that encrypting with multiple keyrings could
+      * fail in unexpected ways.
+      * Additionally, "downstream" keyrings may make choices about the EncryptedDataKeys they
+      * append based on already appended EDK's.
+      */
+      for (const keyring of this.children) {
+        await keyring.onEncrypt(generated, context)
+      }
+
+      // Keyrings are required to not create new EncryptionMaterial instances, but
+      // only append EncryptedDataKey.  Therefore the generated material has all
+      // the data I want.
+      return generated
+    }
+
+    async _onDecrypt (material: DecryptionMaterial<S>, encryptedDataKeys: EncryptedDataKey[], context?: EncryptionContext) {
+      const children = this.children.slice()
+      if (this.generator) children.unshift(this.generator)
+
+      for (const keyring of children) {
+        /* Check for early return (Postcondition): Do not attempt to decrypt once I have a valid key. */
+        if (material.hasValidKey()) return material
+
+        try {
+          await keyring.onDecrypt(material, encryptedDataKeys, context)
+        } catch (e) {
+          // there should be some debug here?  or wrap?
+          // Failures onDecrypt should not short-circuit the process
+          // If the caller does not have access they may have access
+          // through another Keyring.
+        }
+      }
+      return material
+    }
+  }
+  immutableClass(MultiKeyring)
+
+  return MultiKeyring
+}
+
+interface KeyRingConstructible<S extends SupportedAlgorithmSuites> {
+  new(): Keyring<S>
+}
+
+interface MultiKeyringInput<S extends SupportedAlgorithmSuites> {
   generator?: Keyring<S>
   children?: Keyring<S>[]
 }
 
-export class MultiKeyring<S extends SupportedAlgorithmSuites> extends Keyring<S> {
-  public readonly generator?: Keyring<S>
-  public readonly children!: ReadonlyArray<Keyring<S>>
-  constructor ({ generator, children = [] }: MultiKeyringInput<S>) {
-    super()
-    /* Precondition: MultiKeyring must have keyrings. */
-    needs(generator || children.length, 'Noop MultiKeyring is not supported.')
-    /* Precondition: generator must be a Keyring. */
-    needs(!!generator === generator instanceof Keyring, 'Generator must be a Keyring')
-    /* Precondition: All children must be Keyrings. */
-    needs(children.every(kr => kr instanceof Keyring), 'Child must be a Keyring')
-
-    readOnlyProperty(this, 'children', Object.freeze(children.slice()))
-    readOnlyProperty(this, 'generator', generator)
-  }
-
-  async _onEncrypt (material: EncryptionMaterial<S>, context?: EncryptionContext) {
-    const generated = this.generator
-      ? await this.generator.onEncrypt(material, context)
-      : material
-
-    /* Precondition: A Generator Keyring *must* ensure generated material. */
-    needs(this.generator && generated.hasUnencryptedDataKey, 'Generator Keyring has not generated material.')
-    /* Precondition: Only Keyrings explicitly designated as generators can generate material. */
-    needs(generated.hasUnencryptedDataKey, 'Only Keyrings explicitly designated as generators can generate material.')
-
-    /* By default this is a serial operation.  A keyring _may_ perform an expensive operation
-     * or create resource constraints such that encrypting with multiple keyrings could
-     * fail in unexpected ways.
-     * Additionally, "downstream" keyrings may make choices about the EncryptedDataKeys they
-     * append based on already appended EDK's.
-     */
-    for (const keyring of this.children) {
-      await keyring.onEncrypt(generated, context)
-    }
-
-    // Keyrings are required to not create new EncryptionMaterial instances, but
-    // only append EncryptedDataKey.  Therefore the generated material has all
-    // the data I want.
-    return generated
-  }
-
-  async _onDecrypt (material: DecryptionMaterial<S>, encryptedDataKeys: EncryptedDataKey[], context?: EncryptionContext) {
-    const children = this.children.slice()
-    if (this.generator) children.unshift(this.generator)
-
-    for (const keyring of children) {
-      /* Check for early return (Postcondition): Do not attempt to decrypt once I have a valid key. */
-      if (material.hasValidKey()) return material
-
-      try {
-        await keyring.onDecrypt(material, encryptedDataKeys, context)
-      } catch (e) {
-        // there should be some debug here?  or wrap?
-        // Failures onDecrypt should not short-circuit the process
-        // If the caller does not have access they may have access
-        // through another Keyring.
-      }
-    }
-    return material
-  }
+interface MultiKeyring<S extends SupportedAlgorithmSuites> extends Keyring<S> {
+  generator?: Keyring<S>
+  children: ReadonlyArray<Keyring<S>>
 }
-immutableClass(MultiKeyring)
+
+interface MultiKeyringConstructible<S extends SupportedAlgorithmSuites> {
+  new(input: MultiKeyringInput<S>):MultiKeyring<S>
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

MultiKeyring needs to be the right instance to insure that
Node and WebCryto material managers can insure
their keyrings.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
