### PR TITLE
fix: lint and tests

### DIFF
--- a/modules/caching-materials-manager-node/package.json
+++ b/modules/caching-materials-manager-node/package.json
@@ -19,7 +19,6 @@
   "dependencies": {
     "@aws-crypto/material-management-node": "^0.0.1",
     "@aws-crypto/cache-material": "^0.0.1",
-    "@aws-crypto/serialize": "^0.0.1",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/modules/caching-materials-manager-node/src/caching_materials_manager_node.ts
+++ b/modules/caching-materials-manager-node/src/caching_materials_manager_node.ts
@@ -45,7 +45,7 @@ export class NodeCachingMaterialsManager implements CachingMaterialsManager<Node
   readonly _partition!: string
   readonly _maxBytesEncrypted!: number
   readonly _maxMessagesEncrypted!: number
-  readonly _maxAge?: number
+  readonly _maxAge!: number
 
   constructor (input: CachingMaterialsManagerInput<NodeAlgorithmSuite>) {
     const backingMaterialsManager = input.backingMaterials instanceof KeyringNode

--- a/modules/kms-keyring/src/helpers.ts
+++ b/modules/kms-keyring/src/helpers.ts
@@ -49,7 +49,7 @@ export async function generateDataKey<Client extends KMS> (
    * This means that this function will *always* zero out the value returned to it from the KMS client.
    * While this is safe to do here, copying this code somewhere else may produce unexpected results.
    */
-  const {Plaintext} = dataKey
+  const { Plaintext } = dataKey
   dataKey.Plaintext = new Uint8Array(Plaintext)
   Plaintext.fill(0)
   return dataKey
@@ -92,7 +92,7 @@ export async function decrypt<Client extends KMS> (
 
   /* Postcondition: KMS must return usable decrypted key. */
   if (!isRequiredDecryptOutput(dataKey)) throw new Error('Malformed KMS response.')
-  
+
   /* The KMS Client *may* return a Buffer that is not isolated.
    * i.e. the byteOffset !== 0.
    * This means that the unencrypted data key is possibly accessible to someone else.
@@ -101,7 +101,7 @@ export async function decrypt<Client extends KMS> (
    * This means that this function will *always* zero out the value returned to it from the KMS client.
    * While this is safe to do here, copying this code somewhere else may produce unexpected results.
    */
-  const {Plaintext} = dataKey
+  const { Plaintext } = dataKey
   dataKey.Plaintext = new Uint8Array(Plaintext)
   Plaintext.fill(0)
   return dataKey

--- a/modules/kms-keyring/test/helpers.test.ts
+++ b/modules/kms-keyring/test/helpers.test.ts
@@ -40,6 +40,9 @@ describe('kms2EncryptedDataKey', () => {
 
 describe('generateDataKey', () => {
   it('return', async () => {
+    // the string Plaintext as bytes
+    const key = [ 80, 108, 97, 105, 110, 116, 101, 120, 116 ]
+    const Plaintext = new Uint8Array(key)
     const KeyId = 'arn:aws:kms:us-east-1:123456789012:alias/example-alias'
     const GrantTokens = 'grantToken'
     const NumberOfBytes = 128
@@ -54,7 +57,7 @@ describe('generateDataKey', () => {
         expect(input.NumberOfBytes).to.equal(NumberOfBytes)
         expect(input.EncryptionContext).to.equal(EncryptionContext)
         return {
-          Plaintext: 'Plaintext',
+          Plaintext,
           KeyId: 'KeyId',
           CiphertextBlob: 'CiphertextBlob'
         }
@@ -63,7 +66,7 @@ describe('generateDataKey', () => {
 
     const test = await generateDataKey(clientProvider, NumberOfBytes, KeyId, EncryptionContext, GrantTokens)
     if (!test) throw new Error('never')
-    expect(test.Plaintext).to.equal('Plaintext')
+    expect(test.Plaintext).to.deep.equal(new Uint8Array(key))
     expect(test.KeyId).to.equal('KeyId')
     expect(test.CiphertextBlob).to.equal('CiphertextBlob')
   })
@@ -170,6 +173,9 @@ describe('encrypt', () => {
 
 describe('decrypt', () => {
   it('return', async () => {
+    // the string Plaintext as bytes
+    const key = [ 80, 108, 97, 105, 110, 116, 101, 120, 116 ]
+    const Plaintext = new Uint8Array(key)
     const GrantTokens = 'grantToken'
     const KeyId = 'arn:aws:kms:us-east-1:123456789012:alias/example-alias'
     const edk = new EncryptedDataKey({
@@ -188,7 +194,7 @@ describe('decrypt', () => {
         expect(input.EncryptionContext).to.equal(EncryptionContext)
         return {
           KeyId: 'KeyId',
-          Plaintext: 'Plaintext'
+          Plaintext
         }
       }
     }
@@ -196,7 +202,7 @@ describe('decrypt', () => {
     const test = await decrypt(clientProvider, edk, EncryptionContext, GrantTokens)
     if (!test) throw new Error('never')
     expect(test.KeyId).to.equal('KeyId')
-    expect(test.Plaintext).to.equal('Plaintext')
+    expect(test.Plaintext).to.deep.equal(new Uint8Array(key))
   })
 
   it('Precondition:  The EDK must be a KMS edk.', async () => {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* Integrate cacheing materials-manager-node maxAge is not optional
* For KMS tests, plaintext *must* be a Uint8Array, simple string no longer works
* cacheing materials-manager-node does not need a dependancies on serialize
* fix lint

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
