### PR TITLE
fix: import CryptoKey

### DIFF
--- a/modules/material-management-browser/src/index.ts
+++ b/modules/material-management-browser/src/index.ts
@@ -16,6 +16,7 @@
 export * from './browser_cryptographic_materials_manager'
 export * from './material_helpers'
 export * from './bytes2_jwk'
+export * from './keyring_helpers'
 export {
   WebCryptoDecryptionMaterial, WebCryptoEncryptionMaterial, WebCryptoAlgorithmSuite,
   AlgorithmSuiteIdentifier, EncryptionContext, EncryptedDataKey, KeyringWebCrypto,

--- a/modules/material-management-browser/src/keyring_helpers.ts
+++ b/modules/material-management-browser/src/keyring_helpers.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  WebCryptoEncryptionMaterial, // eslint-disable-line no-unused-vars
+  WebCryptoDecryptionMaterial, // eslint-disable-line no-unused-vars
+  WebCryptoMaterial // eslint-disable-line no-unused-vars
+} from '@aws-crypto/material-management'
+
+import {
+  importCryptoKey
+} from './material_helpers'
+
+import {
+  getWebCryptoBackend
+} from '@aws-crypto/web-crypto-backend'
+
+export async function importForWebCryptoEncryptionMaterial (material: WebCryptoEncryptionMaterial) {
+  /* Check for early return (Postcondition): If a cryptoKey has already been imported for encrypt, return. */
+  if (material.hasUnencryptedDataKey && material.hasCryptoKey) return material
+
+  return importCryptoKeyToMaterial(material)
+}
+
+export async function importForWebCryptoDecryptionMaterial (material: WebCryptoDecryptionMaterial) {
+  /* Check for early return (Postcondition): If a cryptoKey has already been imported for decrypt, return. */
+  if (material.hasValidKey()) return material
+  /* Check for early return (Postcondition): If no key was able to be decrypted, return. */
+  if (!material.hasUnencryptedDataKey) return material
+
+  return (await importCryptoKeyToMaterial(material))
+    /* Now that a cryptoKey has been imported, the unencrypted data key can be zeroed.
+     * this is safe, because one and only one EncryptedDataKey should be used to
+     * set the unencrypted data key on the material,
+     * and in the browser, all crypto operations are done with a CryptoKey
+     */
+    .zeroUnencryptedDataKey()
+}
+
+export async function importCryptoKeyToMaterial<T extends WebCryptoMaterial<T>> (
+  material: T
+) {
+  const backend = await getWebCryptoBackend()
+  const cryptoKey = await importCryptoKey(backend, material)
+  // The trace is only set when the material does not already have
+  // an hasUnencryptedDataKey.  This is an implementation detail :(
+  const [trace] = material.keyringTrace
+
+  return material.setCryptoKey(cryptoKey, trace)
+}

--- a/modules/raw-aes-keyring-browser/src/raw_aes_keyring_browser.ts
+++ b/modules/raw-aes-keyring-browser/src/raw_aes_keyring_browser.ts
@@ -26,7 +26,8 @@ import {
   EncryptionContext, // eslint-disable-line no-unused-vars
   getSubtleFunction,
   _importCryptoKey,
-  importCryptoKey
+  importForWebCryptoEncryptionMaterial,
+  importForWebCryptoDecryptionMaterial
 } from '@aws-crypto/material-management-browser'
 import {
   serializeFactory,
@@ -112,7 +113,16 @@ export class RawAesKeyringWebCrypto extends KeyringWebCrypto {
     return providerId === keyNamespace && providerInfo.startsWith(keyName)
   }
 
-  _onEncrypt = _onEncrypt<WebCryptoAlgorithmSuite, RawAesKeyringWebCrypto>(randomValuesOnly)
+  _rawOnEncrypt = _onEncrypt<WebCryptoAlgorithmSuite, RawAesKeyringWebCrypto>(randomValuesOnly)
+  _onEncrypt = async (material: WebCryptoEncryptionMaterial, context?: EncryptionContext) => {
+    const _material = await this._rawOnEncrypt(material, context)
+    return importForWebCryptoEncryptionMaterial(_material)
+  }
+
+  /* onDecrypt does not need to import the crypto key, because this is handled in the unwrap operation
+   * Encrypt needs to have access to the unencrypted data key to encrypt with other keyrings
+   * but once I have functional material no other decrypt operations need to be performed.
+   */
   _onDecrypt = _onDecrypt<WebCryptoAlgorithmSuite, RawAesKeyringWebCrypto>()
 
   static importCryptoKey (masterKey: Uint8Array, wrappingSuite: WrappingSuiteIdentifier) {
@@ -186,8 +196,5 @@ async function aesGcmUnwrapKey (
   const buffer = await KdfGetSubtleDecrypt(info)(iv, aad)(concatBuffers(ciphertext, authTag))
   const trace = { keyNamespace, keyName, flags: decryptFlags }
   material.setUnencryptedDataKey(new Uint8Array(buffer), trace)
-  const cryptoKey = await importCryptoKey(backend, material)
-  return material
-    .zeroUnencryptedDataKey()
-    .setCryptoKey(cryptoKey, trace)
+  return importForWebCryptoDecryptionMaterial(material)
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The browser Keyrings need to import the unencrypted data key
into a CryptoKey.  However, the requirements for this import a
very similar, but slightly different.

Integrate needed functions in `keyring_helpers` and compose
their usage in the implemented keyrings.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
