### PR TITLE
fix: use BufferEncoding

### DIFF
--- a/modules/encrypt-node/src/encrypt.ts
+++ b/modules/encrypt-node/src/encrypt.ts
@@ -12,7 +12,7 @@ import { Readable, Duplex } from 'stream' // eslint-disable-line no-unused-vars
 import { MessageHeader } from '@aws-crypto/serialize' // eslint-disable-line no-unused-vars
 
 interface EncryptInput extends EncryptStreamInput {
-  encoding?: string
+  encoding?: BufferEncoding
 }
 
 export interface EncryptOutput {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Better typing.  This encoding string is passed to
`Buffer.from`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
