### PR TITLE
fix: partition must be set

### DIFF
--- a/modules/cache-material/src/caching_cryptographic_materials_decorators.ts
+++ b/modules/cache-material/src/caching_cryptographic_materials_decorators.ts
@@ -40,7 +40,7 @@ export function decorateProperties<S extends SupportedAlgorithmSuites> (
   obj: CachingMaterialsManager<S>,
   input: CachingMaterialsManagerDecorateInput<S>
 ) {
-  const { cache, backingMaterialsManager, maxAge, maxBytesEncrypted, maxMessagesEncrypted } = input
+  const { cache, backingMaterialsManager, maxAge, maxBytesEncrypted, maxMessagesEncrypted, partition } = input
 
   /* Precondition: A caching material manager needs a cache. */
   needs(cache, 'You must provide a cache.')
@@ -52,12 +52,15 @@ export function decorateProperties<S extends SupportedAlgorithmSuites> (
   needs(!maxBytesEncrypted || (maxBytesEncrypted > 0 && Maximum.BYTES_PER_KEY >= maxBytesEncrypted), 'maxBytesEncrypted is outside of bounds.')
   /* Precondition: maxMessagesEncrypted must be inside bounds.  i.e. positive and not more than the maximum. */
   needs(!maxMessagesEncrypted || (maxMessagesEncrypted > 0 && Maximum.MESSAGES_PER_KEY >= maxMessagesEncrypted), 'maxMessagesEncrypted is outside of bounds.')
+  /* Precondition: partition must be a string. */
+  needs(partition && typeof partition === 'string', 'partition must be a string.')
 
   readOnlyProperty(obj, '_cache', cache)
   readOnlyProperty(obj, '_backingMaterialsManager', backingMaterialsManager)
   readOnlyProperty(obj, '_maxAge', maxAge)
   readOnlyProperty(obj, '_maxBytesEncrypted', maxBytesEncrypted || Maximum.BYTES_PER_KEY)
   readOnlyProperty(obj, '_maxMessagesEncrypted', maxMessagesEncrypted || Maximum.MESSAGES_PER_KEY)
+  readOnlyProperty(obj, '_partition', partition)
 }
 
 export function getEncryptionMaterials<S extends SupportedAlgorithmSuites> (
@@ -184,6 +187,7 @@ export interface CachingMaterialsManagerInput<S extends SupportedAlgorithmSuites
 
 export interface CachingMaterialsManagerDecorateInput<S extends SupportedAlgorithmSuites> extends CachingMaterialsManagerInput<S> {
   backingMaterialsManager: MaterialsManager<S>
+  partition: string
 }
 
 export interface CachingMaterialsManager<S extends SupportedAlgorithmSuites> extends MaterialsManager<S> {

--- a/modules/caching-materials-manager-node/src/caching_materials_manager_node.ts
+++ b/modules/caching-materials-manager-node/src/caching_materials_manager_node.ts
@@ -30,7 +30,7 @@ import {
   KeyringNode
 } from '@aws-crypto/material-management-node'
 
-import { createHash } from 'crypto'
+import { createHash, randomBytes } from 'crypto'
 
 const fromUtf8 = (input: string) => Buffer.from(input, 'utf8')
 const sha512Hex = async (...data: (Uint8Array|string)[]) => data
@@ -52,7 +52,17 @@ export class NodeCachingMaterialsManager implements CachingMaterialsManager<Node
       ? new NodeCryptographicMaterialsManager(input.backingMaterials)
       : <NodeCryptographicMaterialsManager>input.backingMaterials
 
-    decorateProperties(this, { backingMaterialsManager, ...input })
+    /* Precondition: A partition value must exist for NodeCachingMaterialsManager.
+     * The maximum hash function at this time is 512.
+     * So I create 64 bytes of random data.
+     */
+    const { partition = randomBytes(64).toString('utf8') } = input
+
+    decorateProperties(this, {
+      ...input,
+      backingMaterialsManager,
+      partition
+    })
   }
 
   getEncryptionMaterials = getEncryptionMaterials<NodeAlgorithmSuite>(cacheKeyHelpers)

--- a/modules/web-crypto-backend/package.json
+++ b/modules/web-crypto-backend/package.json
@@ -18,7 +18,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-crypto/ie11-detection": "^0.1.0-preview.1",
-    "@aws-crypto/random-source-browser": "^0.1.0-preview.1",
     "@aws-crypto/supports-web-crypto": "^0.1.0-preview.1",
     "@aws-sdk/util-locate-window": "^0.1.0-preview.1",
     "tslib": "^1.9.3"

--- a/modules/web-crypto-backend/src/backend-factory.ts
+++ b/modules/web-crypto-backend/src/backend-factory.ts
@@ -15,19 +15,19 @@
 
 import { isMsWindow } from '@aws-crypto/ie11-detection'
 import { supportsWebCrypto, supportsSubtleCrypto, supportsZeroByteGCM } from '@aws-crypto/supports-web-crypto'
-import { randomValuesOnly as randomValues } from '@aws-crypto/random-source-browser'
+import { synchronousRandomValues as randomValues } from './synchronous_random_values'
 import promisifyMsSubtleCrypto from './promisify-ms-crypto'
 
 type MaybeSubtleCrypto = SubtleCrypto|false
 export type WebCryptoBackend = FullSupportWebCryptoBackend|MixedSupportWebCryptoBackend
 export type FullSupportWebCryptoBackend = {
   subtle: SubtleCrypto
-  randomValues: (byteLength: number) => Promise<Uint8Array>
+  randomValues: (byteLength: number) => Uint8Array
 }
 export type MixedSupportWebCryptoBackend = {
   zeroByteSubtle: SubtleCrypto
   nonZeroByteSubtle: SubtleCrypto
-  randomValues: (byteLength: number) => Promise<Uint8Array>
+  randomValues: (byteLength: number) => Uint8Array
 }
 
 export function webCryptoBackendFactory (window: Window) {
@@ -39,7 +39,7 @@ export function webCryptoBackendFactory (window: Window) {
   async function getWebCryptoBackend (): Promise<WebCryptoBackend> {
     /* Precondition: Access to a secure random source is required. */
     try {
-      await randomValues(1)
+      randomValues(1)
     } catch (ex) {
       throw new Error('No supported secure random')
     }

--- a/modules/web-crypto-backend/src/index.ts
+++ b/modules/web-crypto-backend/src/index.ts
@@ -30,3 +30,5 @@ export {
   FullSupportWebCryptoBackend,
   MixedSupportWebCryptoBackend
 } from './backend-factory'
+
+export { synchronousRandomValues } from './synchronous_random_values'

--- a/modules/web-crypto-backend/src/synchronous_random_values.ts
+++ b/modules/web-crypto-backend/src/synchronous_random_values.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isMsWindow } from '@aws-crypto/ie11-detection'
+import { supportsSecureRandom } from '@aws-crypto/supports-web-crypto'
+import { locateWindow } from '@aws-sdk/util-locate-window'
+
+/* There are uses for a synchronous random source.
+ * For example constructors need to be synchronous.
+ * The AWS JS SDK uses IRandomValues to have a consistent interface.
+ */
+export function synchronousRandomValues (byteLength: number): Uint8Array {
+  // Find the global scope for this runtime
+  const globalScope = locateWindow()
+
+  if (supportsSecureRandom(globalScope)) {
+    return globalScope.crypto.getRandomValues(new Uint8Array(byteLength))
+  } else if (isMsWindow(globalScope)) {
+    const values = new Uint8Array(byteLength)
+    globalScope.msCrypto.getRandomValues(values)
+    return values
+  }
+
+  throw new Error(`Unable to locate a secure random source.`)
+}


### PR DESCRIPTION
The Caching Cryptographic Materials Manager (CCMM) uses a partition to group values in the cache.
The default position should be that different CCMM should *not* cross pollinate values.
Therefore if a partition is not provided, a random value should be set.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
