### PR TITLE
fix: KDF behavior

### DIFF
--- a/modules/material-management-node/src/material_helpers.ts
+++ b/modules/material-management-node/src/material_helpers.ts
@@ -180,16 +180,16 @@ export function nodeKdf (material: NodeEncryptionMaterial|NodeDecryptionMaterial
 
   const { kdf, kdfHash, keyLengthBytes } = material.suite
 
-  /* Check for early return (Postcondition): No KDF, just return the unencrypted data key. */
-  if (!kdf) return dataKey
+  /* Check for early return (Postcondition): No Node.js KDF, just return the unencrypted data key. */
+  if (!kdf && !kdfHash) return dataKey
 
-  /* Precondition: Valid HKDF values must exist. */
+  /* Precondition: Valid HKDF values must exist for Node.js. */
   needs(
     kdf === 'HKDF' &&
     kdfHash &&
     kdfIndex[kdfHash] &&
     info instanceof Uint8Array,
-    ''
+    'Invalid HKDF values.'
   )
   // info and kdfHash are now defined
   const toExtract = Buffer.from(dataKey.buffer, dataKey.byteOffset, dataKey.byteLength)

--- a/modules/material-management-node/test/material_helpers.test.ts
+++ b/modules/material-management-node/test/material_helpers.test.ts
@@ -23,7 +23,7 @@ import { nodeKdf, getCryptoStream, getEncryptHelper, getDecryptionHelper } from 
 import { Decipheriv, Cipheriv, createECDH } from 'crypto'
 
 describe('nodeKdf', () => {
-  it('Check for early return (Postcondition): No KDF, just return the unencrypted data key.', () => {
+  it('Check for early return (Postcondition): No Node.js KDF, just return the unencrypted data key.', () => {
     const suite = new NodeAlgorithmSuite(AlgorithmSuiteIdentifier.ALG_AES128_GCM_IV12_TAG16)
     const material = new NodeEncryptionMaterial(suite)
     const dataKey = new Uint8Array(suite.keyLengthBytes).fill(1)
@@ -58,7 +58,7 @@ describe('nodeKdf', () => {
     expect(test.byteLength).to.equal(suite.keyLengthBytes)
   })
 
-  it('Precondition: Valid HKDF values must exist.', () => {
+  it('Precondition: Valid HKDF values must exist for Node.js.', () => {
     expect(() => nodeKdf({
       getUnencryptedDataKey () {},
       suite: {


### PR DESCRIPTION
#59

The KDF behavior should insure that *both* kdf and kdfHash are defined.
The fall-though should not result in no KDF


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
