### PR TITLE
feat: Add integration testing to CI

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -7,8 +7,8 @@ phases:
         commands:
             - npm install
             - npm run bootstrap
-            - npm run build-node
-            - npm run build-browser
+            - npm run build
     build:
         commands:
             - npm test
+            - npm run integration

--- a/modules/integration-node/package.json
+++ b/modules/integration-node/package.json
@@ -15,12 +15,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-crypto/decrypt-node": "^0.0.1",
-    "@aws-crypto/encrypt-node": "^0.0.1",
-    "@aws-crypto/kms-keyring-node": "^0.0.1",
-    "@aws-crypto/material-management-node": "^0.0.1",
-    "@aws-crypto/raw-aes-keyring-node": "^0.0.1",
-    "@aws-crypto/raw-rsa-keyring-node": "^0.0.1",
+    "@aws-crypto/client-node": "^0.0.1",
     "@types/unzipper": "^0.9.1",
     "@types/yargs": "^13.0.0",
     "tslib": "^1.9.3",

--- a/modules/integration-node/src/decrypt_materials_manager_node.ts
+++ b/modules/integration-node/src/decrypt_materials_manager_node.ts
@@ -15,15 +15,13 @@
 
 import {
   needs,
-  MultiKeyringNode
-} from '@aws-crypto/material-management-node'
-import { KmsKeyringNode } from '@aws-crypto/kms-keyring-node'
-import {
+  MultiKeyringNode,
+  KmsKeyringNode,
   RawAesKeyringNode,
   WrappingSuiteIdentifier, // eslint-disable-line no-unused-vars
-  RawAesWrappingSuiteIdentifier
-} from '@aws-crypto/raw-aes-keyring-node'
-import { RawRsaKeyringNode } from '@aws-crypto/raw-rsa-keyring-node'
+  RawAesWrappingSuiteIdentifier,
+  RawRsaKeyringNode
+} from '@aws-crypto/client-node'
 import {
   RsaKeyInfo, // eslint-disable-line no-unused-vars
   AesKeyInfo, // eslint-disable-line no-unused-vars

--- a/modules/integration-node/src/integration_tests.ts
+++ b/modules/integration-node/src/integration_tests.ts
@@ -18,7 +18,7 @@ import {
   getTestVectorIterator
 } from './get_test_iterator'
 import { decryptMaterialsManagerNode } from './decrypt_materials_manager_node'
-import { decrypt } from '@aws-crypto/decrypt-node'
+import { decrypt } from '@aws-crypto/client-node'
 
 // This is only viable for small streams, if we start get get larger streams, an stream equality should get written
 export async function testVector ({ name, keysInfo, plainTextStream, cipherStream }: TestVectorInfo): Promise<TestVectorResults> {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "npm run lint && npm run build && npm run coverage",
     "integration-browser": "npm run build; lerna run build_fixtures --stream --no-prefix -- -- -v ../../aws-encryption-sdk-test-vectors/vectors/awses-decrypt/python-1.3.8.zip -k",
     "integration-node": "npm run build; lerna run integration_node --stream --no-prefix -- -- -v ../../aws-encryption-sdk-test-vectors/vectors/awses-decrypt/python-1.3.8.zip",
-    "integration": "run-p integration-*"
+    "integration": "run-s integration-*"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
* update integration-node to use client-node
* Run Cross Compatibility for Encryption SDK
* Uses aws-encryption-sdk-test-vectors

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
