### PR TITLE
fix: integration-browser should work from npm

### DIFF
--- a/modules/integration-browser/karma.conf.js
+++ b/modules/integration-browser/karma.conf.js
@@ -8,26 +8,14 @@ module.exports = function (config) {
     files: [
       'fixtures/tests.json',
       { pattern: 'fixtures/*.json', included: false, served: true, watched: false, nocache: true },
-      'src/integration.test.ts'
+      'build/module/integration.test.js'
     ],
     preprocessors: {
-      './src/*.test.ts': ['webpack', 'credentials'],
+      'build/module/integration.test.js': ['webpack', 'credentials'],
       './fixtures/tests.json': ['json_fixtures']
     },
     webpack: {
-      resolve: {
-        extensions: [ '.ts', '.js' ]
-      },
       mode: 'development',
-      module: {
-        rules: [
-          {
-            test: /\.tsx?$/,
-            use: 'ts-loader',
-            exclude: /node_modules/
-          }
-        ]
-      },
       stats: {
         colors: true,
         modules: true,

--- a/modules/integration-browser/package.json
+++ b/modules/integration-browser/package.json
@@ -24,37 +24,23 @@
     "stream-to-promise": "^2.2.0",
     "tslib": "^1.9.3",
     "unzipper": "^0.9.11",
-    "yargs": "^13.2.2"
+    "yargs": "^13.2.2",
+    "jasmine-core": "^3.4.0",
+    "karma": "^4.1.0",
+    "karma-chrome-launcher": "^2.2.0",
+    "karma-jasmine": "^2.0.1",
+    "karma-json-fixtures-preprocessor": "0.0.6",
+    "karma-webpack": "^3.0.5",
+    "webpack": "^4.30.0",
+    "puppeteer": "^1.14.0"
   },
   "devDependencies": {
-    "@types/chai": "^4.1.4",
-    "@types/chai-as-promised": "^7.1.0",
-    "@types/mocha": "^5.2.5",
     "@types/node": "^11.11.4",
     "@typescript-eslint/eslint-plugin": "^1.9.0",
     "@typescript-eslint/parser": "^1.9.0",
-    "chai": "^4.1.2",
-    "chai-as-promised": "^7.1.1",
-    "jasmine-core": "^3.4.0",
-    "karma": "^4.1.0",
-    "karma-chai": "^0.1.0",
-    "karma-chrome-launcher": "^2.2.0",
-    "karma-coverage": "^1.1.2",
-    "karma-jasmine": "^2.0.1",
-    "karma-json-fixtures-preprocessor": "0.0.6",
-    "karma-mocha": "^1.3.0",
-    "karma-typescript": "^4.0.0",
-    "karma-webpack": "^3.0.5",
-    "mocha": "^5.2.0",
-    "mocha-loader": "^2.0.1",
     "nyc": "^14.0.0",
-    "puppeteer": "^1.14.0",
     "standard": "^12.0.1",
-    "ts-loader": "^5.3.3",
-    "ts-node": "^7.0.1",
-    "typescript": "^3.5.0",
-    "webpack": "^4.30.0",
-    "webpack-cli": "^3.3.0"
+    "typescript": "^3.5.0"
   },
   "sideEffects": false,
   "main": "./build/main/index.js",
@@ -63,7 +49,8 @@
   "bin": "./build_fixtures",
   "files": [
     "build/**/*",
-    "build_fixtures"
+    "build_fixtures",
+    "karma.conf.js"
   ],
   "standard": {
     "parser": "@typescript-eslint/parser",


### PR DESCRIPTION
Integration-browser should be able to be installed from npm
and just work.

* include karma.config.js in package
* karma and friends are dependencies, not a devDependencies
* webpack the js files, not the typescript files

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
