### PR TITLE
fix: aws sdk version dependencies pollution

### DIFF
--- a/modules/kms-keyring-node/src/kms_keyring_node.ts
+++ b/modules/kms-keyring-node/src/kms_keyring_node.ts
@@ -49,4 +49,4 @@ export class KmsKeyringNode extends KmsKeyringClass(KeyringNode as KeyRingConstr
 }
 immutableClass(KmsKeyringNode)
 
-export { getKmsClient, cacheKmsClients, limitRegions, excludeRegions, cacheClients }
+export { getKmsClient, cacheKmsClients, getClient, limitRegions, excludeRegions, cacheClients, KMS }

--- a/modules/kms-keyring/package.json
+++ b/modules/kms-keyring/package.json
@@ -17,19 +17,15 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-crypto/material-management": "^0.2.0-preview.1",
-    "@aws-sdk/types": "0.1.0-preview.1",
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "@aws-sdk/client-kms-browser": "^0.1.0-preview.2",
-    "@aws-sdk/client-kms-node": "^0.1.0-preview.2",
     "@types/chai": "^4.1.4",
     "@types/chai-as-promised": "^7.1.0",
     "@types/mocha": "^5.2.5",
     "@types/node": "^11.11.4",
     "@typescript-eslint/eslint-plugin": "^1.9.0",
     "@typescript-eslint/parser": "^1.9.0",
-    "aws-sdk": "^2.443.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "mocha": "^5.2.0",

--- a/modules/kms-keyring/src/helpers.ts
+++ b/modules/kms-keyring/src/helpers.ts
@@ -15,16 +15,13 @@
 
 import { KmsClientSupplier } from './kms_client_supplier' // eslint-disable-line no-unused-vars
 import {
-  KMS, // eslint-disable-line no-unused-vars
-  GenerateDataKeyInput, // eslint-disable-line no-unused-vars
-  EncryptInput, // eslint-disable-line no-unused-vars
-  DecryptInput, // eslint-disable-line no-unused-vars
-  GenerateDataKeyOutput, // eslint-disable-line no-unused-vars
-  RequiredGenerateDataKeyOutput, // eslint-disable-line no-unused-vars
-  EncryptOutput, // eslint-disable-line no-unused-vars
-  RequiredEncryptOutput, // eslint-disable-line no-unused-vars
-  DecryptOutput, // eslint-disable-line no-unused-vars
-  RequiredDecryptOutput // eslint-disable-line no-unused-vars
+  AwsEsdkKMSInterface, // eslint-disable-line no-unused-vars
+  GenerateDataKeyResponse, // eslint-disable-line no-unused-vars
+  RequiredGenerateDataKeyResponse, // eslint-disable-line no-unused-vars
+  EncryptResponse, // eslint-disable-line no-unused-vars
+  RequiredEncryptResponse, // eslint-disable-line no-unused-vars
+  DecryptResponse, // eslint-disable-line no-unused-vars
+  RequiredDecryptResponse // eslint-disable-line no-unused-vars
 } from './kms_types'
 import { regionFromKmsKeyArn } from './region_from_kms_key_arn'
 import {
@@ -35,55 +32,55 @@ import {
 
 export const KMS_PROVIDER_ID = 'aws-kms'
 
-export async function generateDataKey<Client extends KMS> (
+export async function generateDataKey<Client extends AwsEsdkKMSInterface> (
   clientProvider: KmsClientSupplier<Client>,
   NumberOfBytes: number,
   KeyId: string,
   EncryptionContext?: EncryptionContext,
   GrantTokens?: string[]
-): Promise<RequiredGenerateDataKeyOutput|false> {
+): Promise<RequiredGenerateDataKeyResponse|false> {
   const region = regionFromKmsKeyArn(KeyId)
   const client = clientProvider(region)
 
   /* Check for early return (Postcondition): Client region was not provided. */
   if (!client) return false
-  const request: GenerateDataKeyInput<Client> = { KeyId, GrantTokens, NumberOfBytes, EncryptionContext } as GenerateDataKeyInput<Client>
-  // @ts-ignore
-  const v2vsV3Response = client.generateDataKey(request)
-  const v2vsV3Promise = (v2vsV3Response.promise ? v2vsV3Response.promise() : v2vsV3Response)
-  const dataKey: GenerateDataKeyOutput<Client> = await v2vsV3Promise
+  const v2vsV3Response = client.generateDataKey({ KeyId, GrantTokens, NumberOfBytes, EncryptionContext })
+  const v2vsV3Promise = 'promise' in v2vsV3Response
+    ? v2vsV3Response.promise()
+    : v2vsV3Response
+  const dataKey = await v2vsV3Promise
 
   return safeGenerateDataKey(dataKey)
 }
 
-export async function encrypt<Client extends KMS> (
+export async function encrypt<Client extends AwsEsdkKMSInterface> (
   clientProvider: KmsClientSupplier<Client>,
   Plaintext: Uint8Array,
   KeyId: string,
   EncryptionContext?: EncryptionContext,
   GrantTokens?: string[]
-): Promise<RequiredEncryptOutput|false> {
+): Promise<RequiredEncryptResponse|false> {
   const region = regionFromKmsKeyArn(KeyId)
   const client = clientProvider(region)
 
   /* Check for early return (Postcondition): Client region was not provided. */
   if (!client) return false
 
-  const request: EncryptInput<Client> = { KeyId, Plaintext, EncryptionContext, GrantTokens } as EncryptInput<Client>
-  // @ts-ignore
-  const v2vsV3Response = client.encrypt(request)
-  const v2vsV3Promise = (v2vsV3Response.promise ? v2vsV3Response.promise() : v2vsV3Response)
-  const kmsEDK: EncryptOutput<Client> = await v2vsV3Promise
+  const v2vsV3Response = client.encrypt({ KeyId, Plaintext, EncryptionContext, GrantTokens })
+  const v2vsV3Promise = 'promise' in v2vsV3Response
+    ? v2vsV3Response.promise()
+    : v2vsV3Response
+  const kmsEDK = await v2vsV3Promise
 
   return safeEncryptOutput(kmsEDK)
 }
 
-export async function decrypt<Client extends KMS> (
+export async function decrypt<Client extends AwsEsdkKMSInterface> (
   clientProvider: KmsClientSupplier<Client>,
   { providerId, providerInfo, encryptedDataKey }: EncryptedDataKey,
   EncryptionContext?: EncryptionContext,
   GrantTokens?: string[]
-): Promise<RequiredDecryptOutput|false> {
+): Promise<RequiredDecryptResponse|false> {
   /* Precondition:  The EDK must be a KMS edk. */
   needs(providerId === KMS_PROVIDER_ID, 'Unsupported providerId')
   const region = regionFromKmsKeyArn(providerInfo)
@@ -91,14 +88,11 @@ export async function decrypt<Client extends KMS> (
   /* Check for early return (Postcondition): Client region was not provided. */
   if (!client) return false
 
-  const request: DecryptInput<Client> = {
-    CiphertextBlob: encryptedDataKey,
-    EncryptionContext,
-    GrantTokens } as DecryptInput<Client>
-  // @ts-ignore
-  const v2vsV3Response = client.decrypt(request)
-  const v2vsV3Promise = (v2vsV3Response.promise ? v2vsV3Response.promise() : v2vsV3Response)
-  const dataKey: DecryptOutput<Client> = await v2vsV3Promise
+  const v2vsV3Response = client.decrypt({ CiphertextBlob: encryptedDataKey, EncryptionContext, GrantTokens })
+  const v2vsV3Promise = 'promise' in v2vsV3Response
+    ? v2vsV3Response.promise()
+    : v2vsV3Response
+  const dataKey = await v2vsV3Promise
 
   return safeDecryptOutput(dataKey)
 }
@@ -106,42 +100,42 @@ export async function decrypt<Client extends KMS> (
 export function kmsResponseToEncryptedDataKey ({
   KeyId: providerInfo,
   CiphertextBlob: encryptedDataKey
-}: RequiredEncryptOutput) {
+}: RequiredEncryptResponse) {
   return new EncryptedDataKey({ providerId: KMS_PROVIDER_ID, providerInfo, encryptedDataKey })
 }
 
-function safeGenerateDataKey<Client extends KMS> (
-  dataKey: GenerateDataKeyOutput<Client>
-): RequiredGenerateDataKeyOutput {
+function safeGenerateDataKey (
+  dataKey: GenerateDataKeyResponse
+): RequiredGenerateDataKeyResponse {
   /* Postcondition: KMS must return serializable generate data key. */
   needs(typeof dataKey.KeyId === 'string' &&
     dataKey.Plaintext instanceof Uint8Array &&
     dataKey.CiphertextBlob instanceof Uint8Array, 'Malformed KMS response.')
 
-  return <RequiredGenerateDataKeyOutput>safePlaintext(<RequiredGenerateDataKeyOutput>dataKey)
+  return <RequiredGenerateDataKeyResponse>safePlaintext(<RequiredGenerateDataKeyResponse>dataKey)
 }
 
-function safeEncryptOutput<Client extends KMS> (
-  dataKey: EncryptOutput<Client>
-): RequiredEncryptOutput {
+function safeEncryptOutput (
+  dataKey: EncryptResponse
+): RequiredEncryptResponse {
   /* Postcondition: KMS must return serializable encrypted data key. */
   needs(typeof dataKey.KeyId === 'string' &&
     dataKey.CiphertextBlob instanceof Uint8Array, 'Malformed KMS response.')
 
-  return <RequiredEncryptOutput>dataKey
+  return <RequiredEncryptResponse>dataKey
 }
 
-function safeDecryptOutput<Client extends KMS> (
-  dataKey: DecryptOutput<Client>
-): RequiredDecryptOutput {
+function safeDecryptOutput (
+  dataKey: DecryptResponse
+): RequiredDecryptResponse {
   /* Postcondition: KMS must return usable decrypted key. */
   needs(typeof dataKey.KeyId === 'string' &&
     dataKey.Plaintext instanceof Uint8Array, 'Malformed KMS response.')
 
-  return <RequiredDecryptOutput>safePlaintext(<RequiredDecryptOutput>dataKey)
+  return <RequiredDecryptResponse>safePlaintext(<RequiredDecryptResponse>dataKey)
 }
 
-function safePlaintext (dataKey: RequiredDecryptOutput | RequiredGenerateDataKeyOutput): RequiredDecryptOutput | RequiredGenerateDataKeyOutput {
+function safePlaintext (dataKey: RequiredDecryptResponse | RequiredGenerateDataKeyResponse): RequiredDecryptResponse | RequiredGenerateDataKeyResponse {
   /* The KMS Client *may* return a Buffer that is not isolated.
    * i.e. the byteOffset !== 0.
    * This means that the unencrypted data key is possibly accessible to someone else.

--- a/modules/kms-keyring/src/kms_keyring.ts
+++ b/modules/kms-keyring/src/kms_keyring.ts
@@ -15,8 +15,8 @@
 
 import { KmsClientSupplier } from './kms_client_supplier' // eslint-disable-line no-unused-vars
 import {
-  KMS, // eslint-disable-line no-unused-vars
-  RequiredDecryptOutput // eslint-disable-line no-unused-vars
+  AwsEsdkKMSInterface, // eslint-disable-line no-unused-vars
+  RequiredDecryptResponse // eslint-disable-line no-unused-vars
 } from './kms_types'
 import {
   needs,
@@ -34,7 +34,7 @@ import {
 import { KMS_PROVIDER_ID, generateDataKey, encrypt, decrypt, kmsResponseToEncryptedDataKey } from './helpers'
 import { regionFromKmsKeyArn } from './region_from_kms_key_arn'
 
-export interface KmsKeyringInput<Client extends KMS> {
+export interface KmsKeyringInput<Client extends AwsEsdkKMSInterface> {
   clientProvider: KmsClientSupplier<Client>
   keyIds?: string[]
   generatorKeyId?: string
@@ -42,7 +42,7 @@ export interface KmsKeyringInput<Client extends KMS> {
   discovery?: boolean
 }
 
-export interface KeyRing<S extends SupportedAlgorithmSuites, Client extends KMS> extends Keyring<S> {
+export interface KeyRing<S extends SupportedAlgorithmSuites, Client extends AwsEsdkKMSInterface> extends Keyring<S> {
   keyIds: ReadonlyArray<string>
   generatorKeyId?: string
   clientProvider: KmsClientSupplier<Client>
@@ -52,7 +52,7 @@ export interface KeyRing<S extends SupportedAlgorithmSuites, Client extends KMS>
   _onDecrypt(material: DecryptionMaterial<S>, encryptedDataKeys: EncryptedDataKey[], context?: EncryptionContext): Promise<DecryptionMaterial<S>>
 }
 
-export interface KmsKeyRingConstructible<S extends SupportedAlgorithmSuites, Client extends KMS> {
+export interface KmsKeyRingConstructible<S extends SupportedAlgorithmSuites, Client extends AwsEsdkKMSInterface> {
   new(input: KmsKeyringInput<Client>): KeyRing<S, Client>
 }
 
@@ -60,7 +60,7 @@ export interface KeyRingConstructible<S extends SupportedAlgorithmSuites> {
   new(): Keyring<S>
 }
 
-export function KmsKeyringClass<S extends SupportedAlgorithmSuites, Client extends KMS> (
+export function KmsKeyringClass<S extends SupportedAlgorithmSuites, Client extends AwsEsdkKMSInterface> (
   BaseKeyring: KeyRingConstructible<S>
 ): KmsKeyRingConstructible<S, Client> {
   class KmsKeyring extends BaseKeyring implements KeyRing<S, Client> {
@@ -160,7 +160,7 @@ export function KmsKeyringClass<S extends SupportedAlgorithmSuites, Client exten
         })
 
       for (const edk of decryptableEDKs) {
-        let dataKey: RequiredDecryptOutput|false = false
+        let dataKey: RequiredDecryptResponse|false = false
         try {
           dataKey = await decrypt(clientProvider, edk, context, grantTokens)
         } catch (e) {

--- a/modules/kms-keyring/src/kms_types.ts
+++ b/modules/kms-keyring/src/kms_types.ts
@@ -13,80 +13,64 @@
  * limitations under the License.
  */
 
-type KMSv3Node = import('@aws-sdk/client-kms-node').KMS
-type KMSv3Browser = import('@aws-sdk/client-kms-browser').KMS
-type KMSv2 = import('aws-sdk').KMS
-type KMSv3 = KMSv3Browser | KMSv3Node
+import { EncryptionContext } from '@aws-crypto/material-management' // eslint-disable-line no-unused-vars
 
-type KMSConfigV3Browser = import('@aws-sdk/client-kms-browser').KMSConfiguration
-type KMSConfigV3Node = import('@aws-sdk/client-kms-node').KMSConfiguration
-type KMSConfigV2 = import('aws-sdk').KMS.Types.ClientConfiguration
-
-export type KMSConfiguration = KMSConfigV3Browser | KMSConfigV3Node | KMSConfigV2
-export type KMS = KMSv3 | KMSv2
-
-export type GenerateDataKeyInput<Client extends KMS> = Client extends KMSv3Node
-  ? import('@aws-sdk/client-kms-node').GenerateDataKeyInput
-  : Client extends KMSv3Browser
-  ? import('@aws-sdk/client-kms-browser').GenerateDataKeyInput
-  : Client extends KMSv2
-  ? import('aws-sdk').KMS.GenerateDataKeyRequest
-  : never
-
-export type EncryptInput<Client extends KMS> = Client extends KMSv3Node
-  ? import('@aws-sdk/client-kms-node').EncryptInput
-  : Client extends KMSv3Browser
-  ? import('@aws-sdk/client-kms-browser').EncryptInput
-  : Client extends KMSv2
-  ? import('aws-sdk').KMS.EncryptRequest
-  : never
-
-export type DecryptInput<Client extends KMS> = Client extends KMSv3Node
-  ? import('@aws-sdk/client-kms-node').DecryptInput
-  : Client extends KMSv3Browser
-  ? import('@aws-sdk/client-kms-browser').DecryptInput
-  : Client extends KMSv2
-  ? import('aws-sdk').KMS.DecryptRequest
-  : never
-
-export type GenerateDataKeyOutput<Client extends KMS> = Client extends KMSv3Node
-  ? import('@aws-sdk/client-kms-node').GenerateDataKeyOutput
-  : Client extends KMSv3Browser
-  ? import('@aws-sdk/client-kms-browser').GenerateDataKeyOutput
-  : Client extends KMSv2
-  ? import('aws-sdk').KMS.GenerateDataKeyResponse
-  : never
-
-export interface RequiredGenerateDataKeyOutput {
+export interface DecryptRequest {
   CiphertextBlob: Uint8Array
-  Plaintext: Uint8Array
-  KeyId: string
+  EncryptionContext?: EncryptionContext
+  GrantTokens?: string[]
 }
 
-export type EncryptOutput<Client extends KMS> = Client extends KMSv3Node
-  ? import('@aws-sdk/client-kms-node').EncryptOutput
-  : Client extends KMSv3Browser
-  ? import('@aws-sdk/client-kms-browser').EncryptOutput
-  : Client extends KMSv2
-  ? import('aws-sdk').KMS.EncryptResponse
-  : never
-
-export interface RequiredEncryptOutput {
-  CiphertextBlob: Uint8Array
-  KeyId: string
+interface Blob {}
+type Data = string | Buffer | Uint8Array | Blob
+export interface DecryptResponse {
+  KeyId?: string
+  Plaintext?: Data
 }
 
-export type DecryptOutput<Client extends KMS> = Client extends KMSv3Node
-  ? import('@aws-sdk/client-kms-node').DecryptOutput
-  : Client extends KMSv3Browser
-  ? import('@aws-sdk/client-kms-browser').DecryptOutput
-  : Client extends KMSv2
-  ? import('aws-sdk').KMS.DecryptResponse
-  : never
-
-export interface RequiredDecryptOutput {
-  KeyId: string
+export interface RequiredDecryptResponse extends Required<DecryptResponse>{
   Plaintext: Uint8Array
 }
 
-export type KMSOperations = keyof Pick<KMS, 'encrypt'| 'decrypt'| 'generateDataKey'>
+export interface EncryptRequest {
+  KeyId: string
+  Plaintext: Uint8Array
+  EncryptionContext?: EncryptionContext
+  GrantTokens?: string[]
+}
+export interface EncryptResponse {
+  CiphertextBlob?: Data
+  KeyId?: string
+}
+
+export interface RequiredEncryptResponse extends Required<EncryptResponse>{
+  CiphertextBlob: Uint8Array
+}
+
+export interface GenerateDataKeyRequest {
+  KeyId: string
+  EncryptionContext?: EncryptionContext
+  NumberOfBytes?: number
+  GrantTokens?: string[]
+}
+
+export interface GenerateDataKeyResponse {
+  CiphertextBlob?: Data
+  Plaintext?: Data
+  KeyId?: string
+}
+
+export interface RequiredGenerateDataKeyResponse extends Required<GenerateDataKeyResponse>{
+  CiphertextBlob: Uint8Array
+  Plaintext: Uint8Array
+}
+
+export interface AwsSdkV2Response<Response> {
+  promise(): Promise<Response>
+}
+
+export interface AwsEsdkKMSInterface {
+  decrypt(args: DecryptRequest): Promise<DecryptResponse>|AwsSdkV2Response<DecryptResponse>
+  encrypt(args: EncryptRequest): Promise<EncryptResponse>|AwsSdkV2Response<EncryptResponse>
+  generateDataKey(args: GenerateDataKeyRequest): Promise<GenerateDataKeyResponse>|AwsSdkV2Response<GenerateDataKeyResponse>
+}


### PR DESCRIPTION
resolves #136
resolved #138

The AWS SDK for JS v2 and v3 have similar types,
but they are not exactly the same.

In a effort to have both versions work,
I imported as dev dependencies all the relevant packages
and tried to use conditional types.
However, since the types are all exported by the functions
this did not work as planed and caused _every_ client to want _every_ SDK.

The interface the AWS Encryption SDK for JS needs
from the AWS SDK is minimal.
Hand rolling the appropriate types is the best solution at this time.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
