### PR TITLE
feat: Node.js Typescript version dependency

### DIFF
--- a/modules/decrypt-node/src/decipher_stream.ts
+++ b/modules/decrypt-node/src/decipher_stream.ts
@@ -16,8 +16,11 @@
 // @ts-ignore
 import { Transform as PortableTransform } from 'readable-stream'
 import { Transform } from 'stream' // eslint-disable-line no-unused-vars
-import { DecipherGCM } from 'crypto' // eslint-disable-line no-unused-vars
-import { needs } from '@aws-crypto/material-management-node'
+import {
+  needs,
+  GetDecipher, // eslint-disable-line no-unused-vars
+  AwsEsdkJsDecipherGCM // eslint-disable-line no-unused-vars
+} from '@aws-crypto/material-management-node'
 import {
   aadFactory,
   ContentType // eslint-disable-line no-unused-vars
@@ -31,12 +34,12 @@ const PortableTransformWithType = (<new (...args: any[]) => Transform>PortableTr
 export interface DecipherInfo {
   messageId: Buffer
   contentType: ContentType
-  getDecipher: (iv: Uint8Array) => DecipherGCM
+  getDecipher: GetDecipher
   dispose: () => void
 }
 
 interface DecipherState {
-  decipher: DecipherGCM
+  decipher: AwsEsdkJsDecipherGCM
   content: Buffer[]
   contentLength: number
 }

--- a/modules/decrypt-node/src/verify_stream.ts
+++ b/modules/decrypt-node/src/verify_stream.ts
@@ -16,10 +16,10 @@
 // @ts-ignore
 import { Transform as PortableTransform } from 'readable-stream'
 import { Transform } from 'stream' // eslint-disable-line no-unused-vars
-import { DecipherGCM } from 'crypto' // eslint-disable-line no-unused-vars
 import {
   needs,
-  GetVerify // eslint-disable-line no-unused-vars
+  GetVerify, // eslint-disable-line no-unused-vars
+  GetDecipher // eslint-disable-line no-unused-vars
 } from '@aws-crypto/material-management-node'
 import {
   deserializeSignature,
@@ -35,7 +35,7 @@ const PortableTransformWithType = (<new (...args: any[]) => Transform>PortableTr
 
 export interface VerifyInfo {
   headerInfo: HeaderInfo
-  getDecipher: (iv: Uint8Array) => DecipherGCM
+  getDecipher: GetDecipher
   dispose: () => void
   verify?: AWSVerify
 }

--- a/modules/encrypt-node/src/framed_encrypt_stream.ts
+++ b/modules/encrypt-node/src/framed_encrypt_stream.ts
@@ -19,9 +19,12 @@ import {
 } from '@aws-crypto/serialize'
 // @ts-ignore
 import { Transform as PortableTransform } from 'readable-stream'
-import { CipherGCM } from 'crypto' // eslint-disable-line no-unused-vars
 import { Transform } from 'stream' // eslint-disable-line no-unused-vars
-import { needs } from '@aws-crypto/material-management-node'
+import {
+  GetCipher, // eslint-disable-line no-unused-vars
+  AwsEsdkJsCipherGCM, // eslint-disable-line no-unused-vars
+  needs
+} from '@aws-crypto/material-management-node'
 
 const fromUtf8 = (input: string) => Buffer.from(input, 'utf8')
 const serialize = serializeFactory(fromUtf8)
@@ -38,7 +41,7 @@ interface EncryptFrame {
   content: Buffer[]
   bodyHeader: Buffer
   headerSent?: boolean
-  cipher: CipherGCM,
+  cipher: AwsEsdkJsCipherGCM,
   isFinalFrame: boolean
 }
 
@@ -164,8 +167,6 @@ export function getFramedEncryptStream (getCipher: GetCipher, messageHeader: Mes
     }
   })()
 }
-
-type GetCipher = (iv: Uint8Array) => CipherGCM
 
 type EncryptFrameInput = {
   pendingFrame: AccumulatingFrame,

--- a/modules/material-management-node/src/index.ts
+++ b/modules/material-management-node/src/index.ts
@@ -18,7 +18,11 @@ export {
   getEncryptHelper,
   getDecryptionHelper,
   GetSigner,
-  GetVerify
+  GetVerify,
+  GetCipher,
+  GetDecipher,
+  AwsEsdkJsCipherGCM,
+  AwsEsdkJsDecipherGCM
 } from './material_helpers'
 export {
   NodeDecryptionMaterial, NodeEncryptionMaterial, NodeAlgorithmSuite,

--- a/modules/raw-rsa-keyring-node/src/raw_rsa_keyring_node.ts
+++ b/modules/raw-rsa-keyring-node/src/raw_rsa_keyring_node.ts
@@ -30,8 +30,7 @@ import {
   constants,
   publicEncrypt,
   privateDecrypt,
-  randomBytes,
-  KeyObject // eslint-disable-line no-unused-vars
+  randomBytes
 } from 'crypto'
 
 import {
@@ -52,8 +51,8 @@ import {
  * or more complicated options...  Thoughts?
  */
 interface RsaKey {
-  publicKey?: string | Buffer | KeyObject
-  privateKey?: string | Buffer | KeyObject
+  publicKey?: string | Buffer
+  privateKey?: string | Buffer
 }
 
 export type RawRsaKeyringNodeInput = {


### PR DESCRIPTION
resolves #135

The AWS Encryption SDK should track the Node.js LTS policy.
For developers using Typescript and @types/node@8
the ESDK should “just work”.
Because some packages export Node.js types like `CipherGCM`
developers would be forced to install an unwanted type version.

This pulls in the needed parts of the needed types into the packages.
It is only the types that differ in this case.

Regarding KeyObjects, rsa support is removed,
but will be added back in when #74 is addressed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
