### PR TITLE
fix: material-management should not export DOM types

### DIFF
--- a/modules/material-management/src/signature_key.ts
+++ b/modules/material-management/src/signature_key.ts
@@ -18,6 +18,7 @@ import { encodeNamedCurves } from './ecc_encode'
 import { decodeNamedCurves } from './ecc_decode'
 import { frozenClass, readOnlyBinaryProperty, readOnlyProperty } from './immutable_class'
 import { publicKeyPem, privateKeyPem } from './pem_helpers'
+import { AwsEsdkJsCryptoKey } from './types' // eslint-disable-line no-unused-vars
 
 /*
  * This public interface to the SignatureKey object is provided for
@@ -27,10 +28,10 @@ import { publicKeyPem, privateKeyPem } from './pem_helpers'
  */
 
 export class SignatureKey {
-  public readonly privateKey!: string|CryptoKey
+  public readonly privateKey!: string|AwsEsdkJsCryptoKey
   public readonly compressPoint!: Uint8Array
   public readonly signatureCurve!: NodeECDHCurve|WebCryptoECDHCurve
-  constructor (privateKey: Uint8Array|CryptoKey, compressPoint: Uint8Array, suite: AlgorithmSuite) {
+  constructor (privateKey: Uint8Array|AwsEsdkJsCryptoKey, compressPoint: Uint8Array, suite: AlgorithmSuite) {
     const { signatureCurve: namedCurve } = suite
     /* Precondition: Do not create a SignatureKey for an algorithm suite that does not have an EC named curve. */
     if (!namedCurve) throw new Error('Unsupported Algorithm')
@@ -63,9 +64,9 @@ export class SignatureKey {
 frozenClass(SignatureKey)
 
 export class VerificationKey {
-  public readonly publicKey!: string|CryptoKey
+  public readonly publicKey!: string|AwsEsdkJsCryptoKey
   public readonly signatureCurve!: NodeECDHCurve|WebCryptoECDHCurve
-  constructor (publicKey: Uint8Array|CryptoKey, suite: AlgorithmSuite) {
+  constructor (publicKey: Uint8Array|AwsEsdkJsCryptoKey, suite: AlgorithmSuite) {
     const { signatureCurve: namedCurve } = suite
     /* Precondition: Do not create a VerificationKey for an algorithm suite that does not have an EC named curve. */
     if (!namedCurve) throw new Error('Unsupported Algorithm')

--- a/modules/material-management/src/types.ts
+++ b/modules/material-management/src/types.ts
@@ -23,9 +23,23 @@ import {
 
 export type EncryptionContext = {[index: string]: string}
 
+/* need to copy some things from DOM */
+export interface AwsEsdkJsKeyAlgorithm {
+  name: string
+}
+export type AwsEsdkJsKeyType = 'public' | 'private' | 'secret'
+export type AwsEsdkJsKeyUsage = 'encrypt' | 'decrypt' | 'sign' | 'verify' | 'deriveKey' | 'deriveBits' | 'wrapKey' | 'unwrapKey'
+
+export interface AwsEsdkJsCryptoKey {
+  readonly algorithm: AwsEsdkJsKeyAlgorithm
+  readonly extractable: boolean
+  readonly type: AwsEsdkJsKeyType
+  readonly usages: AwsEsdkJsKeyUsage[]
+}
+
 export type MixedBackendCryptoKey = {
-  nonZeroByteCryptoKey: CryptoKey
-  zeroByteCryptoKey: CryptoKey
+  nonZeroByteCryptoKey: AwsEsdkJsCryptoKey
+  zeroByteCryptoKey: AwsEsdkJsCryptoKey
 }
 
 export interface EncryptionRequest<S extends NodeAlgorithmSuite|WebCryptoAlgorithmSuite> {

--- a/modules/raw-keyring/src/raw_aes_material.ts
+++ b/modules/raw-keyring/src/raw_aes_material.ts
@@ -29,6 +29,8 @@ import {
   frozenClass,
   NodeAlgorithmSuite,
   WebCryptoAlgorithmSuite,
+  AwsEsdkJsCryptoKey, // eslint-disable-line no-unused-vars
+  AwsEsdkJsKeyUsage, // eslint-disable-line no-unused-vars
   KeyringTrace, // eslint-disable-line no-unused-vars
   KeyringTraceFlag,
   needs
@@ -77,15 +79,15 @@ export class WebCryptoRawAesMaterial implements
   hasUnencryptedDataKey!: boolean
   unencryptedDataKeyLength!: number
   keyringTrace: KeyringTrace[] = []
-  setCryptoKey!: (dataKey: CryptoKey|MixedBackendCryptoKey, trace: KeyringTrace) => WebCryptoRawAesMaterial
-  getCryptoKey!: () => CryptoKey|MixedBackendCryptoKey
+  setCryptoKey!: (dataKey: AwsEsdkJsCryptoKey|MixedBackendCryptoKey, trace: KeyringTrace) => WebCryptoRawAesMaterial
+  getCryptoKey!: () => AwsEsdkJsCryptoKey|MixedBackendCryptoKey
   hasCryptoKey!: boolean
-  validUsages: ReadonlyArray<KeyUsage>
+  validUsages: ReadonlyArray<AwsEsdkJsKeyUsage>
   constructor (suiteId: WrappingSuiteIdentifier) {
     /* Precondition: WebCryptoAlgorithmSuite suiteId must be RawAesWrappingSuiteIdentifier. */
     needs(RawAesWrappingSuiteIdentifier[suiteId], 'suiteId not supported.')
     this.suite = new WebCryptoAlgorithmSuite(suiteId)
-    this.validUsages = Object.freeze([<KeyUsage>'decrypt', <KeyUsage>'encrypt'])
+    this.validUsages = Object.freeze([<AwsEsdkJsKeyUsage>'decrypt', <AwsEsdkJsKeyUsage>'encrypt'])
     /* WebCryptoRawAesMaterial need to set a flag, this is an abuse of TraceFlags
      * because the material is not generated.
      * but CryptographicMaterial force a flag to be set.


### PR DESCRIPTION
resolves #137

Cryptographic materials need to understand CryptoKeys
to insure that a given algorithm suite is satisfied.
However, by exporting the DOM types in function calls,
all dependent modules must import DOM types.
This pollution is not needed,
especially for node packages.

Pull the type structure into the module and export
that interface.
Update raw_aes_materials to use new types.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
