### PR TITLE
fix: frame length can not be 0

### DIFF
--- a/modules/encrypt-browser/src/encrypt.ts
+++ b/modules/encrypt-browser/src/encrypt.ts
@@ -63,7 +63,7 @@ export async function encrypt (
   { suiteId, encryptionContext, frameLength = FRAME_LENGTH }: EncryptInput = {}
 ): Promise<EncryptResult> {
   /* Precondition: The frameLength must be less than the maximum frame size for browser encryption. */
-  needs(frameLength > 0 && Maximum.FRAME_SIZE >= frameLength, 'frameLength out of bounds')
+  needs(frameLength > 0 && Maximum.FRAME_SIZE >= frameLength, `frameLength out of bounds: 0 > frameLength >= ${Maximum.FRAME_SIZE}`)
 
   const backend = await getWebCryptoBackend()
   if (!backend) throw new Error('No supported crypto backend')

--- a/modules/encrypt-browser/src/encrypt.ts
+++ b/modules/encrypt-browser/src/encrypt.ts
@@ -21,6 +21,7 @@ import {
   AlgorithmSuiteIdentifier,
   getEncryptHelper,
   KeyringWebCrypto,
+  needs,
   WebCryptoMaterialsManager // eslint-disable-line no-unused-vars
 } from '@aws-crypto/material-management-browser'
 import {
@@ -35,7 +36,8 @@ import {
   serializeSignatureInfo,
   FRAME_LENGTH,
   MESSAGE_ID_LENGTH,
-  raw2der
+  raw2der,
+  Maximum
 } from '@aws-crypto/serialize'
 import { fromUtf8 } from '@aws-sdk/util-utf8-browser'
 import { getWebCryptoBackend } from '@aws-crypto/web-crypto-backend'
@@ -60,6 +62,10 @@ export async function encrypt (
   plaintext: Uint8Array,
   { suiteId, encryptionContext, frameLength = FRAME_LENGTH }: EncryptInput = {}
 ): Promise<EncryptResult> {
+
+  /* Precondition: The frameLength must be less than the maximum frame size for browser encryption. */
+  needs(frameLength > 0 && Maximum.FRAME_SIZE >= frameLength, 'frameLength out of bounds')
+
   const backend = await getWebCryptoBackend()
   if (!backend) throw new Error('No supported crypto backend')
 

--- a/modules/encrypt-browser/src/encrypt.ts
+++ b/modules/encrypt-browser/src/encrypt.ts
@@ -62,7 +62,6 @@ export async function encrypt (
   plaintext: Uint8Array,
   { suiteId, encryptionContext, frameLength = FRAME_LENGTH }: EncryptInput = {}
 ): Promise<EncryptResult> {
-
   /* Precondition: The frameLength must be less than the maximum frame size for browser encryption. */
   needs(frameLength > 0 && Maximum.FRAME_SIZE >= frameLength, 'frameLength out of bounds')
 

--- a/modules/encrypt-browser/test/encrypt.test.ts
+++ b/modules/encrypt-browser/test/encrypt.test.ts
@@ -85,4 +85,9 @@ describe('encrypt structural testing', () => {
 
     expect(messageHeader).to.deep.equal(messageInfo.messageHeader)
   })
+
+  it('Precondition: The frameLength must be less than the maximum frame size for browser encryption.', async () => {
+    const frameLength = 0
+    expect(encrypt(keyRing, 'asdf', { frameLength })).to.rejectedWith(Error)
+  })
 })

--- a/modules/encrypt-node/src/encrypt_stream.ts
+++ b/modules/encrypt-node/src/encrypt_stream.ts
@@ -16,7 +16,8 @@
 import {
   NodeDefaultCryptographicMaterialsManager, NodeAlgorithmSuite, AlgorithmSuiteIdentifier, // eslint-disable-line no-unused-vars
   KeyringNode, NodeEncryptionMaterial, getEncryptHelper, EncryptionContext, // eslint-disable-line no-unused-vars
-  NodeMaterialsManager // eslint-disable-line no-unused-vars
+  NodeMaterialsManager, // eslint-disable-line no-unused-vars
+  needs
 } from '@aws-crypto/material-management-node'
 import { getFramedEncryptStream } from './framed_encrypt_stream'
 import { SignatureStream } from './signature_stream'
@@ -26,7 +27,8 @@ import {
   MessageHeader, // eslint-disable-line no-unused-vars
   serializeFactory, kdfInfo, ContentType, SerializationVersion, ObjectType,
   FRAME_LENGTH,
-  MESSAGE_ID_LENGTH
+  MESSAGE_ID_LENGTH,
+  Maximum
 } from '@aws-crypto/serialize'
 
 // @ts-ignore
@@ -55,6 +57,9 @@ export function encryptStream (
   op: EncryptStreamInput = {}
 ): Duplex {
   const { suiteId, context, frameLength = FRAME_LENGTH } = op
+
+  /* Precondition: The frameLength must be less than the maximum frame size Node.js stream. */
+  needs(frameLength > 0 && Maximum.FRAME_SIZE >= frameLength, 'frameLength out of bounds')
 
   /* If the cmm is a Keyring, wrap it with NodeDefaultCryptographicMaterialsManager. */
   cmm = cmm instanceof KeyringNode

--- a/modules/encrypt-node/src/encrypt_stream.ts
+++ b/modules/encrypt-node/src/encrypt_stream.ts
@@ -59,7 +59,7 @@ export function encryptStream (
   const { suiteId, context, frameLength = FRAME_LENGTH } = op
 
   /* Precondition: The frameLength must be less than the maximum frame size Node.js stream. */
-  needs(frameLength > 0 && Maximum.FRAME_SIZE >= frameLength, 'frameLength out of bounds')
+  needs(frameLength > 0 && Maximum.FRAME_SIZE >= frameLength, `frameLength out of bounds: 0 > frameLength >= ${Maximum.FRAME_SIZE}`)
 
   /* If the cmm is a Keyring, wrap it with NodeDefaultCryptographicMaterialsManager. */
   cmm = cmm instanceof KeyringNode

--- a/modules/encrypt-node/test/encrypt.test.ts
+++ b/modules/encrypt-node/test/encrypt.test.ts
@@ -184,6 +184,11 @@ describe('encrypt structural testing', () => {
 
     expect(messageHeader).to.deep.equal(messageInfo.messageHeader)
   })
+
+  it('Precondition: The frameLength must be less than the maximum frame size Node.js stream.', async () => {
+    const frameLength = 0
+    expect(encrypt(keyRing, 'asdf', { frameLength })).to.rejectedWith(Error)
+  })
 })
 
 function finishedAsync (stream: any) {


### PR DESCRIPTION
resolves #129

The other ESDK’s use frameLength === 0 to indicate non-framed content.
The JS ESDK does not support encrypting non-framed content.
A frameLength of 0 will crash the process.
Add condition and test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
