### PR TITLE
fix: Multi keyrings should not require a generator

### DIFF
--- a/modules/material-management/src/multi_keyring.ts
+++ b/modules/material-management/src/multi_keyring.ts
@@ -78,7 +78,7 @@ function buildPrivateOnEncrypt<S extends SupportedAlgorithmSuites> () {
      * then generated.hasUnencryptedDataKey === false will throw.
      * But this is a much more meaningful error.
      */
-    needs(!material.hasUnencryptedDataKey ? this.generator : true , 'Only Keyrings explicitly designated as generators can generate material.')
+    needs(!material.hasUnencryptedDataKey ? this.generator : true, 'Only Keyrings explicitly designated as generators can generate material.')
 
     const generated = this.generator
       ? await this.generator.onEncrypt(material, context)

--- a/modules/material-management/test/multi_keyring.test.ts
+++ b/modules/material-management/test/multi_keyring.test.ts
@@ -202,7 +202,7 @@ describe('MultiKeyring: onEncrypt', () => {
     })
 
     const mkeyring = new MultiKeyringNode({  children:[ child ] })
-    const material = new NodeEncryptionMaterial(suite) //.setUnencryptedDataKey(unencryptedDataKey, keyringTrace0)
+    const material = new NodeEncryptionMaterial(suite)
     return expect(mkeyring.onEncrypt(material)).to.rejectedWith(Error, 'Only Keyrings explicitly designated as generators can generate material.')
   })
 

--- a/modules/material-management/test/multi_keyring.test.ts
+++ b/modules/material-management/test/multi_keyring.test.ts
@@ -201,7 +201,7 @@ describe('MultiKeyring: onEncrypt', () => {
       onDecrypt: never
     })
 
-    const mkeyring = new MultiKeyringNode({  children:[ child ] })
+    const mkeyring = new MultiKeyringNode({ children: [ child ] })
     const material = new NodeEncryptionMaterial(suite)
     return expect(mkeyring.onEncrypt(material)).to.rejectedWith(Error, 'Only Keyrings explicitly designated as generators can generate material.')
   })
@@ -234,7 +234,7 @@ describe('MultiKeyring: onEncrypt', () => {
       onDecrypt: never
     })
 
-    const mkeyring = new MultiKeyringNode({ children: [ child ]  })
+    const mkeyring = new MultiKeyringNode({ children: [ child ] })
     const material = new NodeEncryptionMaterial(suite).setUnencryptedDataKey(unencryptedDataKey, keyringTrace0)
 
     await mkeyring.onEncrypt(material)

--- a/modules/material-management/test/multi_keyring.test.ts
+++ b/modules/material-management/test/multi_keyring.test.ts
@@ -202,7 +202,7 @@ describe('MultiKeyring: onEncrypt', () => {
     })
 
     const mkeyring = new MultiKeyringNode({ children: [ child ] })
-    const material = new NodeEncryptionMaterial(suite)
+    const material = new NodeEncryptionMaterial(suite, {})
     return expect(mkeyring.onEncrypt(material)).to.rejectedWith(Error, 'Only Keyrings explicitly designated as generators can generate material.')
   })
 
@@ -235,7 +235,7 @@ describe('MultiKeyring: onEncrypt', () => {
     })
 
     const mkeyring = new MultiKeyringNode({ children: [ child ] })
-    const material = new NodeEncryptionMaterial(suite).setUnencryptedDataKey(unencryptedDataKey, keyringTrace0)
+    const material = new NodeEncryptionMaterial(suite, {}).setUnencryptedDataKey(unencryptedDataKey, keyringTrace0)
 
     await mkeyring.onEncrypt(material)
   })


### PR DESCRIPTION
If a multi keyring did not have a generator,
but was passed material with an unencrypted data key,
it would throw.
This is incorrect.
Better code, tests, and error messages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

