### PR TITLE
fix: CI encrypt/decrypt test vectors

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "aws-encryption-sdk-test-vectors"]
 	path = aws-encryption-sdk-test-vectors
-	url = git@github.com:awslabs/aws-encryption-sdk-test-vectors.git
+	url = https://github.com/awslabs/aws-encryption-sdk-test-vectors.git

--- a/modules/integration-browser/karma.conf.js
+++ b/modules/integration-browser/karma.conf.js
@@ -47,7 +47,7 @@ module.exports = function (config) {
     customLaunchers: {
       ChromeHeadlessDisableCors: {
         base: 'ChromeHeadless',
-        flags: ['--disable-web-security']
+        flags: ['--disable-web-security', '--no-sandbox']
       }
     },
     singleRun: true,

--- a/modules/integration-browser/src/cli.ts
+++ b/modules/integration-browser/src/cli.ts
@@ -81,6 +81,8 @@ if (!existsSync(fixtures)) {
 
   if (command === 'decrypt') {
     const { vectorFile } = argv
+    const vectorPath = join(__dirname, vectorFile as string)
+    if (!existsSync(vectorPath)) throw new Error(`No file found at ${vectorPath}`)
     // @ts-ignore
     await buildDecryptFixtures(fixtures, vectorFile, testName, slice)
   } else if (command === 'encrypt') {

--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
     "test": "npm run lint && npm run build && npm run coverage",
     "integration-browser-decrypt": "npm run build; lerna run build_fixtures --stream --no-prefix -- -- decrypt -v $npm_package_config_localTestVectors --karma",
     "integration-browser-encrypt": "npm run build; lerna run build_fixtures --stream --no-prefix -- -- encrypt -m $npm_package_config_encryptManifestList -k $npm_package_config_encryptKeyManifest -o $npm_package_config_decryptOracle --karma",
-    "integration-browser": "run-s integration-browser-*",
+    "browser-integration": "run-s integration-browser-*",
     "integration-node-decrypt": "npm run build; lerna run integration_node --stream --no-prefix -- -- decrypt -v $npm_package_config_localTestVectors",
     "integration-node-encrypt": "npm run build; lerna run integration_node --stream --no-prefix -- -- encrypt -m $npm_package_config_encryptManifestList -k $npm_package_config_encryptKeyManifest -o $npm_package_config_decryptOracle",
-    "integration-node": "run-s integration-node-*",
+    "node-integration": "run-s integration-node-*",
     "integration": "run-s integration-*",
     "test_conditions": "./util/bootstrap_tsconfig"
   },


### PR DESCRIPTION
* add no-sandbox to integration-browser
  see: https://bugs.chromium.org/p/chromium/issues/detail?id=638180
* Update submodule to use https
* change the names on integration to only run all tests once

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

