### PR TITLE
fix: cloned material that exceeds limits

### DIFF
--- a/modules/cache-material/src/caching_cryptographic_materials_decorators.ts
+++ b/modules/cache-material/src/caching_cryptographic_materials_decorators.ts
@@ -110,9 +110,15 @@ export function getEncryptionMaterials<S extends SupportedAlgorithmSuites> (
     }
     if (!this._cacheEntryHasExceededLimits(testEntry)) {
       this._cache.putEncryptionMaterial(cacheKey, material, plaintextLength, this._maxAge)
+      return cloneResponse(material)
+    } else {
+      /* Postcondition: If the material has exceeded limits it MUST NOT be cloned.
+       * If it is cloned, and the clone is returned,
+       * then there exist a copy of the unencrypted data key.
+       * It is true that this data would be caught by GC, it is better to just not rely on that.
+       */
+      return material
     }
-
-    return cloneResponse(material)
   }
 }
 


### PR DESCRIPTION
It is possible for material that is created in the caching CMM to immediately exceed the caching limits. In this case the materials clearly should not be cached, but also they should not be cloned.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

