### PR TITLE
fix: ENCODED_SIGNER_KEY in encryption context

### DIFF
--- a/modules/material-management-browser/src/browser_cryptographic_materials_manager.ts
+++ b/modules/material-management-browser/src/browser_cryptographic_materials_manager.ts
@@ -49,7 +49,7 @@ export class WebCryptoDefaultCryptographicMaterialsManager implements WebCryptoM
   async getEncryptionMaterials ({ suite, encryptionContext }: WebCryptoEncryptionRequest): Promise<WebCryptoEncryptionMaterial> {
     suite = suite || new WebCryptoAlgorithmSuite(AlgorithmSuiteIdentifier.ALG_AES256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384)
 
-    /* Precondition: WebCryptoDefaultCryptographicMaterialsManager should reserve the ENCODED_SIGNER_KEY constant from @aws-crypto/serialize.
+    /* Precondition: WebCryptoDefaultCryptographicMaterialsManager must reserve the ENCODED_SIGNER_KEY constant from @aws-crypto/serialize.
      * A CryptographicMaterialsManager can change entries to the encryptionContext
      * but changing these values has consequences.
      * The DefaultCryptographicMaterialsManager uses the value in the encryption context to store public signing key.

--- a/modules/material-management-browser/test/browser_cryptographic_materials_manager.test.ts
+++ b/modules/material-management-browser/test/browser_cryptographic_materials_manager.test.ts
@@ -240,7 +240,7 @@ describe('WebCryptoDefaultCryptographicMaterialsManager', () => {
     expect(material.encryptionContext).to.have.haveOwnProperty('some').and.to.equal('context')
   })
 
-  it('Precondition: WebCryptoDefaultCryptographicMaterialsManager should reserve the ENCODED_SIGNER_KEY constant from @aws-crypto/serialize.', async () => {
+  it('Precondition: WebCryptoDefaultCryptographicMaterialsManager must reserve the ENCODED_SIGNER_KEY constant from @aws-crypto/serialize.', async () => {
     class TestKeyring extends KeyringWebCrypto {
       async _onEncrypt (): Promise<WebCryptoEncryptionMaterial> {
         throw new Error('I should never see this error')

--- a/modules/material-management-browser/test/browser_cryptographic_materials_manager.test.ts
+++ b/modules/material-management-browser/test/browser_cryptographic_materials_manager.test.ts
@@ -240,6 +240,25 @@ describe('WebCryptoDefaultCryptographicMaterialsManager', () => {
     expect(material.encryptionContext).to.have.haveOwnProperty('some').and.to.equal('context')
   })
 
+  it('Precondition: WebCryptoDefaultCryptographicMaterialsManager should reserve the ENCODED_SIGNER_KEY constant from @aws-crypto/serialize.', async () => {
+    class TestKeyring extends KeyringWebCrypto {
+      async _onEncrypt (): Promise<WebCryptoEncryptionMaterial> {
+        throw new Error('I should never see this error')
+      }
+      async _onDecrypt (): Promise<WebCryptoDecryptionMaterial> {
+        throw new Error('I should never see this error')
+      }
+    }
+
+    const keyring = new TestKeyring()
+    const cmm = new WebCryptoDefaultCryptographicMaterialsManager(keyring)
+    const encryptionContext = {
+      [ENCODED_SIGNER_KEY]: 'context'
+    }
+
+    expect(cmm.getEncryptionMaterials({ encryptionContext })).to.rejectedWith(Error, 'Reserved encryptionContext value')
+  })
+
   it('Postcondition: The WebCryptoEncryptionMaterial must contain a valid dataKey.', async () => {
     class TestKeyring extends KeyringWebCrypto {
       async _onEncrypt (material: WebCryptoEncryptionMaterial): Promise<WebCryptoEncryptionMaterial> {

--- a/modules/material-management-node/src/node_cryptographic_materials_manager.ts
+++ b/modules/material-management-node/src/node_cryptographic_materials_manager.ts
@@ -49,7 +49,7 @@ export class NodeDefaultCryptographicMaterialsManager implements NodeMaterialsMa
   async getEncryptionMaterials ({ suite, encryptionContext }: NodeEncryptionRequest): Promise<NodeEncryptionMaterial> {
     suite = suite || new NodeAlgorithmSuite(AlgorithmSuiteIdentifier.ALG_AES256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384)
 
-    /* Precondition: NodeDefaultCryptographicMaterialsManager should reserve the ENCODED_SIGNER_KEY constant from @aws-crypto/serialize.
+    /* Precondition: NodeDefaultCryptographicMaterialsManager must reserve the ENCODED_SIGNER_KEY constant from @aws-crypto/serialize.
      * A CryptographicMaterialsManager can change entries to the encryptionContext
      * but changing these values has consequences.
      * The DefaultCryptographicMaterialsManager uses the value in the encryption context to store public signing key.

--- a/modules/material-management-node/test/node_cryptographic_materials_manager.test.ts
+++ b/modules/material-management-node/test/node_cryptographic_materials_manager.test.ts
@@ -183,6 +183,24 @@ describe('NodeDefaultCryptographicMaterialsManager', () => {
     )).to.throw()
   })
 
+  it('Precondition: NodeDefaultCryptographicMaterialsManager should reserve the ENCODED_SIGNER_KEY constant from @aws-crypto/serialize.', async () => {
+    class TestKeyring extends KeyringNode {
+      async _onEncrypt (): Promise<NodeEncryptionMaterial> {
+        throw new Error('this should never happen')
+      }
+      async _onDecrypt (): Promise<NodeDecryptionMaterial> {
+        throw new Error('this should never happen')
+      }
+    }
+    const keyring = new TestKeyring()
+    const cmm = new NodeDefaultCryptographicMaterialsManager(keyring)
+    const encryptionContext = {
+      [ENCODED_SIGNER_KEY]: 'something'
+    }
+
+    await expect(cmm.getEncryptionMaterials({ encryptionContext })).to.rejectedWith(Error, 'Reserved encryptionContext value')
+  })
+
   it('Postcondition: The NodeEncryptionMaterial must contain a valid dataKey.', async () => {
     const suite = new NodeAlgorithmSuite(AlgorithmSuiteIdentifier.ALG_AES128_GCM_IV12_TAG16_HKDF_SHA256_ECDSA_P256)
 

--- a/modules/material-management-node/test/node_cryptographic_materials_manager.test.ts
+++ b/modules/material-management-node/test/node_cryptographic_materials_manager.test.ts
@@ -183,7 +183,7 @@ describe('NodeDefaultCryptographicMaterialsManager', () => {
     )).to.throw()
   })
 
-  it('Precondition: NodeDefaultCryptographicMaterialsManager should reserve the ENCODED_SIGNER_KEY constant from @aws-crypto/serialize.', async () => {
+  it('Precondition: NodeDefaultCryptographicMaterialsManager must reserve the ENCODED_SIGNER_KEY constant from @aws-crypto/serialize.', async () => {
     class TestKeyring extends KeyringNode {
       async _onEncrypt (): Promise<NodeEncryptionMaterial> {
         throw new Error('this should never happen')


### PR DESCRIPTION
A CryptographicMaterialsManager can change entries to the encryptionContext
but changing these values has consequences.
The DefaultCryptographicMaterialsManager uses the value in the encryption context
to store public signing key.
If the caller is using this value in their encryption context the Default CMM
is probably not the CMM they want to use.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

