### PR TITLE
fix: integration silent errors

### DIFF
--- a/modules/integration-browser/src/build_decrypt_fixtures.ts
+++ b/modules/integration-browser/src/build_decrypt_fixtures.ts
@@ -27,7 +27,7 @@ import { DecryptManifestList } from './types' // eslint-disable-line no-unused-v
  * 1. The code is not tied to a specific copy of the manifest information
  * 2. The tests can be run on a subset of tests for debugging.
  */
-export async function buildDecryptFixtures (fixtures: string, vectorFile: string, testName: string, slice: string) {
+export async function buildDecryptFixtures (fixtures: string, vectorFile: string, testName?: string, slice?: string) {
   const [start = 0, end = 9999] = (slice || '').split(':').map(n => parseInt(n, 10))
 
   const centralDirectory = await Open.file(vectorFile)

--- a/modules/integration-browser/src/build_encrypt_fixtures.ts
+++ b/modules/integration-browser/src/build_encrypt_fixtures.ts
@@ -34,7 +34,7 @@ import got from 'got'
  * 1. The code is not tied to a specific copy of the manifest information
  * 2. The tests can be run on a subset of tests for debugging.
  */
-export async function buildEncryptFixtures (fixtures: string, manifestFile: string, keyFile: string, testName: string, slice: string) {
+export async function buildEncryptFixtures (fixtures: string, manifestFile: string, keyFile: string, testName?: string, slice?: string) {
   const [start = 0, end = 9999] = (slice || '').split(':').map(n => parseInt(n, 10))
   const { tests, plaintexts }: EncryptManifestList = await getParsedJSON(manifestFile)
   const { keys }: KeyList = await getParsedJSON(keyFile)

--- a/modules/integration-browser/src/cli.ts
+++ b/modules/integration-browser/src/cli.ts
@@ -73,22 +73,22 @@ if (!existsSync(fixtures)) {
 }
 
 ;(async (argv) => {
-  const { _: [ command ], testName, slice, karma, decryptOracle = '' } = argv
+  const { _: [ command ], testName, slice, karma } = argv
 
   writeFileSync(`${fixtures}/decrypt_tests.json`, JSON.stringify([]))
   writeFileSync(`${fixtures}/encrypt_tests.json`, JSON.stringify([]))
-  writeFileSync(`${fixtures}/decrypt_oracle.json`, JSON.stringify(decryptOracle))
 
   if (command === 'decrypt') {
-    const { vectorFile } = argv
-    const vectorPath = join(__dirname, vectorFile as string)
-    if (!existsSync(vectorPath)) throw new Error(`No file found at ${vectorPath}`)
-    // @ts-ignore
-    await buildDecryptFixtures(fixtures, vectorFile, testName, slice)
+    // It is not clear how to get yargs/typescript to play nicely with sub commands
+    const { vectorFile } = argv as unknown as { vectorFile: string}
+    if (!existsSync(vectorFile)) throw new Error(`No file found at ${vectorFile}`)
+    await buildDecryptFixtures(fixtures, vectorFile as string, testName, slice)
   } else if (command === 'encrypt') {
-    const { manifestFile, keyFile } = argv
-    // @ts-ignore
-    await buildEncryptFixtures(fixtures, manifestFile, keyFile, testName, slice)
+    // It is not clear how to get yargs/typescript to play nicely with sub commands
+    const { manifestFile, keyFile, decryptOracle } = argv as unknown as { manifestFile: string, keyFile: string, decryptOracle: string}
+    writeFileSync(`${fixtures}/decrypt_oracle.json`, JSON.stringify(decryptOracle))
+
+    await buildEncryptFixtures(fixtures, manifestFile as string, keyFile as string, testName, slice)
   } else {
     console.log(`Unknown command ${command}`)
     cli.showHelp()
@@ -101,3 +101,7 @@ if (!existsSync(fixtures)) {
     })
   }
 })(cli.argv)
+.catch(err => {
+  console.log(err)
+  process.exit(1)
+})

--- a/modules/integration-browser/src/cli.ts
+++ b/modules/integration-browser/src/cli.ts
@@ -101,7 +101,7 @@ if (!existsSync(fixtures)) {
     })
   }
 })(cli.argv)
-.catch(err => {
-  console.log(err)
-  process.exit(1)
-})
+  .catch(err => {
+    console.log(err)
+    process.exit(1)
+  })

--- a/modules/integration-node/src/cli.ts
+++ b/modules/integration-node/src/cli.ts
@@ -64,12 +64,10 @@ const cli = yargs
   /* I set the result to 1 so that if I fall through the exit condition is a failure */
   let result = 1
   if (command === 'decrypt') {
-    const { vectorFile } = argv
-    // @ts-ignore
+    const { vectorFile } = argv as unknown as { vectorFile: string}
     result = await integrationDecryptTestVectors(vectorFile, tolerateFailures, testName)
   } else if (command === 'encrypt') {
-    const { manifestFile, keyFile, decryptOracle } = argv
-    // @ts-ignore
+    const { manifestFile, keyFile, decryptOracle } = argv as unknown as { manifestFile: string, keyFile: string, decryptOracle: string}
     result = await integrationEncryptTestVectors(manifestFile, keyFile, decryptOracle, tolerateFailures, testName)
   } else {
     console.log(`Unknown command ${command}`)
@@ -78,3 +76,7 @@ const cli = yargs
 
   if (result) process.exit(result)
 })(cli.argv)
+.catch(err => {
+  console.log(err)
+  process.exit(1)
+})

--- a/modules/integration-node/src/cli.ts
+++ b/modules/integration-node/src/cli.ts
@@ -76,7 +76,7 @@ const cli = yargs
 
   if (result) process.exit(result)
 })(cli.argv)
-.catch(err => {
-  console.log(err)
-  process.exit(1)
-})
+  .catch(err => {
+    console.log(err)
+    process.exit(1)
+  })


### PR DESCRIPTION
The cli’s for the integration packages could silently error.
The logic is wrapped in an immediately invoked function expression.
The function is async, and if there is an error
this results in an unhandled promise rejection.
Catch the error, log, and exit with a non-zero code.

I also cleaned up some of the path expressions,
and removed the ts-ignore.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

