### PR TITLE
feat: Remove unencryptedDataKeyLength

### DIFF
--- a/modules/material-management/src/cryptographic_material.ts
+++ b/modules/material-management/src/cryptographic_material.ts
@@ -80,7 +80,6 @@ export interface CryptographicMaterial<T extends CryptographicMaterial<T>> {
   getUnencryptedDataKey: () => Uint8Array
   zeroUnencryptedDataKey: () => T
   hasUnencryptedDataKey: boolean
-  unencryptedDataKeyLength: number
   keyringTrace: KeyringTrace[]
   encryptionContext: Readonly<EncryptionContext>
 }
@@ -112,7 +111,6 @@ export class NodeEncryptionMaterial implements
   getUnencryptedDataKey!: () => Uint8Array
   zeroUnencryptedDataKey!: () => NodeEncryptionMaterial
   hasUnencryptedDataKey!: boolean
-  unencryptedDataKeyLength!: number
   keyringTrace: KeyringTrace[] = []
   encryptedDataKeys!: EncryptedDataKey[]
   addEncryptedDataKey!: (edk: EncryptedDataKey, flags: KeyringTraceFlag) => NodeEncryptionMaterial
@@ -147,7 +145,6 @@ export class NodeDecryptionMaterial implements
   getUnencryptedDataKey!: () => Uint8Array
   zeroUnencryptedDataKey!: () => NodeDecryptionMaterial
   hasUnencryptedDataKey!: boolean
-  unencryptedDataKeyLength!: number
   keyringTrace: KeyringTrace[] = []
   setVerificationKey!: (key: VerificationKey) => NodeDecryptionMaterial
   verificationKey?: VerificationKey
@@ -181,7 +178,6 @@ export class WebCryptoEncryptionMaterial implements
   getUnencryptedDataKey!: () => Uint8Array
   zeroUnencryptedDataKey!: () => WebCryptoEncryptionMaterial
   hasUnencryptedDataKey!: boolean
-  unencryptedDataKeyLength!: number
   keyringTrace: KeyringTrace[] = []
   encryptedDataKeys!: EncryptedDataKey[]
   addEncryptedDataKey!: (edk: EncryptedDataKey, flags: KeyringTraceFlag) => WebCryptoEncryptionMaterial
@@ -223,7 +219,6 @@ export class WebCryptoDecryptionMaterial implements
   getUnencryptedDataKey!: () => Uint8Array
   zeroUnencryptedDataKey!: () => WebCryptoDecryptionMaterial
   hasUnencryptedDataKey!: boolean
-  unencryptedDataKeyLength!: number
   keyringTrace: KeyringTrace[] = []
   setVerificationKey!: (key: VerificationKey) => WebCryptoDecryptionMaterial
   verificationKey?: VerificationKey
@@ -345,21 +340,6 @@ export function decorateCryptographicMaterial<T extends CryptographicMaterial<T>
     needs(unsetCount === 0 || unsetCount === 2, 'Either unencryptedDataKey or udkForVerification was not set.')
     return material
   }
-  Object.defineProperty(material, 'unencryptedDataKeyLength', {
-    get: () => {
-      /* Precondition: The unencryptedDataKey must be set to have a length. */
-      needs(unencryptedDataKey, 'unencryptedDataKey has not been set')
-      /* Precondition: the unencryptedDataKey must not be Zeroed out.
-       * returning information about the data key,
-       * while not the worst thing may indicate misuse.
-       * Checking the algorithm specification is the proper way
-       * to do this
-       */
-      needs(!unencryptedDataKeyZeroed, 'unencryptedDataKey has been zeroed.')
-      return unencryptedDataKey.byteLength
-    },
-    enumerable: true
-  })
 
   readOnlyProperty(material, 'setUnencryptedDataKey', setUnencryptedDataKey)
   readOnlyProperty(material, 'getUnencryptedDataKey', getUnencryptedDataKey)

--- a/modules/material-management/test/cryptographic_material.test.ts
+++ b/modules/material-management/test/cryptographic_material.test.ts
@@ -56,7 +56,6 @@ describe('decorateCryptographicMaterial', () => {
     const dataKey = new Uint8Array(suite.keyLengthBytes).fill(1)
     test.setUnencryptedDataKey(dataKey, { keyNamespace: 'k', keyName: 'k', flags: KeyringTraceFlag.WRAPPING_KEY_GENERATED_DATA_KEY })
     expect(test.hasUnencryptedDataKey).to.equal(true)
-    expect(test.unencryptedDataKeyLength).to.equal(dataKey.byteLength)
     expect(test.getUnencryptedDataKey()).to.deep.equal(dataKey)
   })
 
@@ -84,27 +83,11 @@ describe('decorateCryptographicMaterial', () => {
     test.setUnencryptedDataKey(dataKey, { keyNamespace: 'k', keyName: 'k', flags: KeyringTraceFlag.WRAPPING_KEY_GENERATED_DATA_KEY })
     test.zeroUnencryptedDataKey()
     expect(() => test.getUnencryptedDataKey()).to.throw()
-    expect(() => test.unencryptedDataKeyLength).to.throw()
   })
 
   it('Precondition: unencryptedDataKey must be set before we can return it.', () => {
     const test: any = decorateCryptographicMaterial((<any>{}), KeyringTraceFlag.WRAPPING_KEY_GENERATED_DATA_KEY)
     expect(() => test.getUnencryptedDataKey()).to.throw()
-  })
-
-  it('Precondition: The unencryptedDataKey must be set to have a length.', () => {
-    const test: any = decorateCryptographicMaterial((<any>{}), KeyringTraceFlag.WRAPPING_KEY_GENERATED_DATA_KEY)
-    expect(() => test.unencryptedDataKeyLength).to.throw()
-  })
-
-  it('Precondition: the unencryptedDataKey must not be Zeroed out.', () => {
-    const suite = new NodeAlgorithmSuite(AlgorithmSuiteIdentifier.ALG_AES128_GCM_IV12_TAG16)
-    const test = decorateCryptographicMaterial((<any>{ suite, keyringTrace: [] }), KeyringTraceFlag.WRAPPING_KEY_GENERATED_DATA_KEY)
-    const dataKey = new Uint8Array(suite.keyLengthBytes).fill(1)
-    const trace = { keyNamespace: 'k', keyName: 'k', flags: KeyringTraceFlag.WRAPPING_KEY_GENERATED_DATA_KEY }
-    test.setUnencryptedDataKey(dataKey, trace)
-    test.zeroUnencryptedDataKey()
-    expect(() => test.unencryptedDataKeyLength).to.throw('unencryptedDataKey has been zeroed.')
   })
 
   it(`Precondition: If the unencryptedDataKey has not been set, it should not be settable later.

--- a/modules/raw-keyring/src/raw_aes_material.ts
+++ b/modules/raw-keyring/src/raw_aes_material.ts
@@ -49,7 +49,6 @@ export class NodeRawAesMaterial implements
   getUnencryptedDataKey!: () => Uint8Array
   zeroUnencryptedDataKey!: () => NodeRawAesMaterial
   hasUnencryptedDataKey!: boolean
-  unencryptedDataKeyLength!: number
   keyringTrace: KeyringTrace[] = []
   encryptionContext: EncryptionContext = Object.freeze({})
   constructor (suiteId: WrappingSuiteIdentifier) {
@@ -79,7 +78,6 @@ export class WebCryptoRawAesMaterial implements
   getUnencryptedDataKey!: () => Uint8Array
   zeroUnencryptedDataKey!: () => WebCryptoRawAesMaterial
   hasUnencryptedDataKey!: boolean
-  unencryptedDataKeyLength!: number
   keyringTrace: KeyringTrace[] = []
   setCryptoKey!: (dataKey: AwsEsdkJsCryptoKey|MixedBackendCryptoKey, trace: KeyringTrace) => WebCryptoRawAesMaterial
   getCryptoKey!: () => AwsEsdkJsCryptoKey|MixedBackendCryptoKey


### PR DESCRIPTION
It is a feature that is not being used.
This was created to let callers confirm that the unencrypted data key matched the algorithm suite,
but this checking is done directly into the cryptographic material now.
The `hasUnencryptedDataKey` is the best way to check for existence,
and the materials themselves will ensure that algorithm suite specifications are meet.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

