### PR TITLE
fix: Zero length frames in old version of Node

### DIFF
--- a/modules/decrypt-node/src/decipher_stream.ts
+++ b/modules/decrypt-node/src/decipher_stream.ts
@@ -160,6 +160,10 @@ export function getDecipherStream () {
       decipherState = {} as any
 
       decipher.setAuthTag(authTag)
+      /* In Node.js versions 10.9 and older will fail to decrypt if decipher.update is not called.
+       * https://github.com/nodejs/node/pull/22538 fixes this.
+       */
+      if (!content.length) decipher.update(Buffer.alloc(0))
 
       const clear: Buffer[] = []
       for (const cipherChunk of content) {


### PR DESCRIPTION
resolves #199

In Node.js versions 10.9 and older will fail to decrypt if decipher.update is not called.
https://github.com/nodejs/node/pull/22538 fixes this.

If the content is empty, push an empty buffer.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

