### PR TITLE
fix: Update user agent calls to KMS

### DIFF
--- a/modules/kms-keyring-browser/src/kms_keyring_browser.ts
+++ b/modules/kms-keyring-browser/src/kms_keyring_browser.ts
@@ -36,7 +36,7 @@ import {
 } from '@aws-crypto/material-management-browser'
 import { KMS } from 'aws-sdk' // eslint-disable-line no-unused-vars
 
-const getKmsClient = getClient(KMS)
+const getKmsClient = getClient(KMS, { customUserAgent: 'AwsEncryptionSdkJavascriptBrowser' })
 const cacheKmsClients = cacheClients(getKmsClient)
 
 export type KmsKeyringWebCryptoInput = Partial<KmsKeyringInput<KMS>>

--- a/modules/kms-keyring-node/src/kms_keyring_node.ts
+++ b/modules/kms-keyring-node/src/kms_keyring_node.ts
@@ -29,7 +29,7 @@ import {
   immutableClass, KeyringNode
 } from '@aws-crypto/material-management-node'
 import { KMS } from 'aws-sdk' // eslint-disable-line no-unused-vars
-const getKmsClient = getClient(KMS)
+const getKmsClient = getClient(KMS, { customUserAgent: 'AwsEncryptionSdkJavascriptNodejs' })
 const cacheKmsClients = cacheClients(getKmsClient)
 
 export type KmsKeyringNodeInput = Partial<KmsKeyringInput<KMS>>


### PR DESCRIPTION
We want to identify which implementation of the AWS Encryption SDK
is being used in order to assist in any requests from customers
or for debugging as necessary by developers.
We plan to utilize the user agent set by the SDK to achieve this.

This identification is done in the default `clientProvider`.
Users can create their own `clientProvider`,
and set a different user agent.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

