### PR TITLE
chore: Add publish step to GHA release workflow

### DIFF
--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -77,9 +77,9 @@ jobs:
       # Ensure npm 11.5.1 or later is installed
       - name: Update npm
         run: npm install -g npm@latest
-      - run: npm ci
+      - run: npm ci --unsafe-perm
       - run: npm run build --if-present
-      - run: npm publish
+      - run: npx lerna publish from-package --yes --dist-tag ${{ github.event.inputs.dist_tag }}
 
   # Once publishing is complete, validate that the published packages are useable
   validate:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

New publish step is a combination of 
* npm trusted publishing steps https://docs.npmjs.com/trusted-publishers
* existing CodeBuild publish step https://github.com/aws/aws-encryption-sdk-javascript/blob/master/codebuild/release/publish.yml

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

