### PR TITLE
chore: workaround https://github.com/nodejs/node/issues/62425

### DIFF
--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -98,7 +98,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '22.22.1'
           registry-url: 'https://registry.npmjs.org'
 
       # Ensure npm 11.5.1 or later is installed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,29 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [5.0.0](https://github.com/awslabs/aws-encryption-sdk-javascript/compare/v4.2.2...v5.0.0) (2026-04-23)
-
-### Bug Fixes
-
-- **ci:** fix VERSION_BUMP scoping and remove unused NPM token from publish job ([#1653](https://github.com/awslabs/aws-encryption-sdk-javascript/issues/1653)) ([6fd56ea](https://github.com/awslabs/aws-encryption-sdk-javascript/commit/6fd56ea4ac135bf7b28faa935b5cd20412ffd4bc))
-- **ci:** force pull in publish step ([#1639](https://github.com/awslabs/aws-encryption-sdk-javascript/issues/1639)) ([6b74c8c](https://github.com/awslabs/aws-encryption-sdk-javascript/commit/6b74c8cd573290f33ea0142ea3e5da68005e0468))
-- **ci:** npm otp fix for publish ([#1641](https://github.com/awslabs/aws-encryption-sdk-javascript/issues/1641)) ([fcaf49f](https://github.com/awslabs/aws-encryption-sdk-javascript/commit/fcaf49f31821f8453f8ad34e9766efd39084c5ca))
-- **ci:** npm token for publish ([#1640](https://github.com/awslabs/aws-encryption-sdk-javascript/issues/1640)) ([953ae60](https://github.com/awslabs/aws-encryption-sdk-javascript/commit/953ae609cd19e4bf508613bb06bac8ed3574f784))
-- mitigate dependency issues — remove deprecated packages ([#1654](https://github.com/awslabs/aws-encryption-sdk-javascript/issues/1654)) ([d795278](https://github.com/awslabs/aws-encryption-sdk-javascript/commit/d795278bfc6f9d023545f0b36bef701ba5387081))
-- Removes the internal added prefix from custom encryption context before creating the branch key material node object ([#1650](https://github.com/awslabs/aws-encryption-sdk-javascript/issues/1650)) ([9907b1b](https://github.com/awslabs/aws-encryption-sdk-javascript/commit/9907b1ba70233edf96ce56eb0e8eb094b93c517f))
-
-- feat!: Drop IE11 support (#1651) ([f11b277](https://github.com/awslabs/aws-encryption-sdk-javascript/commit/f11b277b802180e89532ff83bced7440e42247e0)), closes [#1651](https://github.com/awslabs/aws-encryption-sdk-javascript/issues/1651)
-
-### Features
-
-- Adds create and version branch key functionality ([#1652](https://github.com/awslabs/aws-encryption-sdk-javascript/issues/1652)) ([6fab564](https://github.com/awslabs/aws-encryption-sdk-javascript/commit/6fab56475d4d2521bca859a66f7ce759aad7ba44)), closes [#1642](https://github.com/awslabs/aws-encryption-sdk-javascript/issues/1642)
-
-### BREAKING CHANGES
-
-- The AWS Encryption SDK for JavaScript no longer supports Internet Explorer 11 (IE11). The msCrypto shim and related IE11 detection code have been removed from the web-crypto-backend module.
-
-Co-authored-by: Lucas McDonald <lucmcdon@amazon.com>
-
 ## [4.2.2](https://github.com/awslabs/aws-encryption-sdk-javascript/compare/v4.2.1...v4.2.2) (2026-03-05)
 
 ### Bug Fixes

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "packages": ["modules/*"],
-  "version": "5.0.0",
+  "version": "4.2.2",
   "command": {
     "bootstrap": {
       "nohoist": ["typedoc"]

--- a/modules/branch-keystore-node/CHANGELOG.md
+++ b/modules/branch-keystore-node/CHANGELOG.md
@@ -3,16 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [5.0.0](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.2...v5.0.0) (2026-04-23)
-
-### Bug Fixes
-
-- Removes the internal added prefix from custom encryption context before creating the branch key material node object ([#1650](https://github.com/aws/aws-encryption-sdk-javascript/issues/1650)) ([9907b1b](https://github.com/aws/aws-encryption-sdk-javascript/commit/9907b1ba70233edf96ce56eb0e8eb094b93c517f))
-
-### Features
-
-- Adds create and version branch key functionality ([#1652](https://github.com/aws/aws-encryption-sdk-javascript/issues/1652)) ([6fab564](https://github.com/aws/aws-encryption-sdk-javascript/commit/6fab56475d4d2521bca859a66f7ce759aad7ba44)), closes [#1642](https://github.com/aws/aws-encryption-sdk-javascript/issues/1642)
-
 ## [4.2.2](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.1...v4.2.2) (2026-03-05)
 
 ### Bug Fixes

--- a/modules/branch-keystore-node/package.json
+++ b/modules/branch-keystore-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-crypto/branch-keystore-node",
-  "version": "5.0.0",
+  "version": "4.2.2",
   "scripts": {
     "prepublishOnly": "npm run generate-version.ts; npm run build",
     "generate-version.ts": "npx genversion --es6  src/version.ts",

--- a/modules/cache-material/CHANGELOG.md
+++ b/modules/cache-material/CHANGELOG.md
@@ -3,10 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [5.0.0](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.2...v5.0.0) (2026-04-23)
-
-**Note:** Version bump only for package @aws-crypto/cache-material
-
 ## [4.2.2](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.1...v4.2.2) (2026-03-05)
 
 ### Bug Fixes

--- a/modules/cache-material/package.json
+++ b/modules/cache-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-crypto/cache-material",
-  "version": "5.0.0",
+  "version": "4.2.2",
   "scripts": {
     "prepublishOnly": "npm run build",
     "build": "tsc -b tsconfig.json && tsc -b tsconfig.module.json",

--- a/modules/caching-materials-manager-browser/CHANGELOG.md
+++ b/modules/caching-materials-manager-browser/CHANGELOG.md
@@ -3,12 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [5.0.0](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.2...v5.0.0) (2026-04-23)
-
-### Bug Fixes
-
-- mitigate dependency issues — remove deprecated packages ([#1654](https://github.com/aws/aws-encryption-sdk-javascript/issues/1654)) ([d795278](https://github.com/aws/aws-encryption-sdk-javascript/commit/d795278bfc6f9d023545f0b36bef701ba5387081))
-
 ## [4.2.2](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.1...v4.2.2) (2026-03-05)
 
 **Note:** Version bump only for package @aws-crypto/caching-materials-manager-browser

--- a/modules/caching-materials-manager-browser/package.json
+++ b/modules/caching-materials-manager-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-crypto/caching-materials-manager-browser",
-  "version": "5.0.0",
+  "version": "4.2.2",
   "scripts": {
     "prepublishOnly": "npm run build",
     "build": "tsc -b tsconfig.json && tsc -b tsconfig.module.json",

--- a/modules/caching-materials-manager-node/CHANGELOG.md
+++ b/modules/caching-materials-manager-node/CHANGELOG.md
@@ -3,10 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [5.0.0](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.2...v5.0.0) (2026-04-23)
-
-**Note:** Version bump only for package @aws-crypto/caching-materials-manager-node
-
 ## [4.2.2](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.1...v4.2.2) (2026-03-05)
 
 **Note:** Version bump only for package @aws-crypto/caching-materials-manager-node

--- a/modules/caching-materials-manager-node/package.json
+++ b/modules/caching-materials-manager-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-crypto/caching-materials-manager-node",
-  "version": "5.0.0",
+  "version": "4.2.2",
   "scripts": {
     "prepublishOnly": "npm run build",
     "build": "tsc -b tsconfig.json && tsc -b tsconfig.module.json",

--- a/modules/client-browser/CHANGELOG.md
+++ b/modules/client-browser/CHANGELOG.md
@@ -3,10 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [5.0.0](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.2...v5.0.0) (2026-04-23)
-
-**Note:** Version bump only for package @aws-crypto/client-browser
-
 ## [4.2.2](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.1...v4.2.2) (2026-03-05)
 
 **Note:** Version bump only for package @aws-crypto/client-browser

--- a/modules/client-browser/package.json
+++ b/modules/client-browser/package.json
@@ -9,7 +9,7 @@
     "CSE",
     "aws"
   ],
-  "version": "5.0.0",
+  "version": "4.2.2",
   "scripts": {
     "build": "tsc -b tsconfig.json",
     "lint": "run-s lint-*",

--- a/modules/client-node/CHANGELOG.md
+++ b/modules/client-node/CHANGELOG.md
@@ -3,10 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [5.0.0](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.2...v5.0.0) (2026-04-23)
-
-**Note:** Version bump only for package @aws-crypto/client-node
-
 ## [4.2.2](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.1...v4.2.2) (2026-03-05)
 
 **Note:** Version bump only for package @aws-crypto/client-node

--- a/modules/client-node/package.json
+++ b/modules/client-node/package.json
@@ -9,7 +9,7 @@
     "CSE",
     "aws"
   ],
-  "version": "5.0.0",
+  "version": "4.2.2",
   "scripts": {
     "build": "tsc -b tsconfig.json",
     "lint": "run-s lint-*",

--- a/modules/decrypt-browser/CHANGELOG.md
+++ b/modules/decrypt-browser/CHANGELOG.md
@@ -3,12 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [5.0.0](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.2...v5.0.0) (2026-04-23)
-
-### Bug Fixes
-
-- mitigate dependency issues — remove deprecated packages ([#1654](https://github.com/aws/aws-encryption-sdk-javascript/issues/1654)) ([d795278](https://github.com/aws/aws-encryption-sdk-javascript/commit/d795278bfc6f9d023545f0b36bef701ba5387081))
-
 ## [4.2.2](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.1...v4.2.2) (2026-03-05)
 
 **Note:** Version bump only for package @aws-crypto/decrypt-browser

--- a/modules/decrypt-browser/package.json
+++ b/modules/decrypt-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-crypto/decrypt-browser",
-  "version": "5.0.0",
+  "version": "4.2.2",
   "scripts": {
     "prepublishOnly": "tsc -p tsconfig.json && tsc -p tsconfig.module.json",
     "lint": "run-s lint-*",

--- a/modules/decrypt-node/CHANGELOG.md
+++ b/modules/decrypt-node/CHANGELOG.md
@@ -3,10 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [5.0.0](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.2...v5.0.0) (2026-04-23)
-
-**Note:** Version bump only for package @aws-crypto/decrypt-node
-
 ## [4.2.2](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.1...v4.2.2) (2026-03-05)
 
 **Note:** Version bump only for package @aws-crypto/decrypt-node

--- a/modules/decrypt-node/package.json
+++ b/modules/decrypt-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-crypto/decrypt-node",
-  "version": "5.0.0",
+  "version": "4.2.2",
   "scripts": {
     "prepublishOnly": "npm run build",
     "build": "tsc -b tsconfig.json && tsc -b tsconfig.module.json",

--- a/modules/encrypt-browser/CHANGELOG.md
+++ b/modules/encrypt-browser/CHANGELOG.md
@@ -3,12 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [5.0.0](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.2...v5.0.0) (2026-04-23)
-
-### Bug Fixes
-
-- mitigate dependency issues — remove deprecated packages ([#1654](https://github.com/aws/aws-encryption-sdk-javascript/issues/1654)) ([d795278](https://github.com/aws/aws-encryption-sdk-javascript/commit/d795278bfc6f9d023545f0b36bef701ba5387081))
-
 ## [4.2.2](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.1...v4.2.2) (2026-03-05)
 
 **Note:** Version bump only for package @aws-crypto/encrypt-browser

--- a/modules/encrypt-browser/package.json
+++ b/modules/encrypt-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-crypto/encrypt-browser",
-  "version": "5.0.0",
+  "version": "4.2.2",
   "scripts": {
     "prepublishOnly": "tsc -p tsconfig.json && tsc -p tsconfig.module.json",
     "lint": "run-s lint-*",

--- a/modules/encrypt-node/CHANGELOG.md
+++ b/modules/encrypt-node/CHANGELOG.md
@@ -3,10 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [5.0.0](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.2...v5.0.0) (2026-04-23)
-
-**Note:** Version bump only for package @aws-crypto/encrypt-node
-
 ## [4.2.2](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.1...v4.2.2) (2026-03-05)
 
 **Note:** Version bump only for package @aws-crypto/encrypt-node

--- a/modules/encrypt-node/package.json
+++ b/modules/encrypt-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-crypto/encrypt-node",
-  "version": "5.0.0",
+  "version": "4.2.2",
   "scripts": {
     "prepublishOnly": "tsc -p tsconfig.json && tsc -p tsconfig.module.json",
     "lint": "run-s lint-*",

--- a/modules/example-browser/CHANGELOG.md
+++ b/modules/example-browser/CHANGELOG.md
@@ -3,12 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [5.0.0](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.2...v5.0.0) (2026-04-23)
-
-### Bug Fixes
-
-- mitigate dependency issues — remove deprecated packages ([#1654](https://github.com/aws/aws-encryption-sdk-javascript/issues/1654)) ([d795278](https://github.com/aws/aws-encryption-sdk-javascript/commit/d795278bfc6f9d023545f0b36bef701ba5387081))
-
 ## [4.2.2](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.1...v4.2.2) (2026-03-05)
 
 **Note:** Version bump only for package @aws-crypto/example-browser

--- a/modules/example-browser/package.json
+++ b/modules/example-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-crypto/example-browser",
-  "version": "5.0.0",
+  "version": "4.2.2",
   "scripts": {
     "prepublishOnly": "npm run build",
     "build": "tsc -b tsconfig.json && tsc -b tsconfig.module.json",

--- a/modules/example-node/CHANGELOG.md
+++ b/modules/example-node/CHANGELOG.md
@@ -3,10 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [5.0.0](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.2...v5.0.0) (2026-04-23)
-
-**Note:** Version bump only for package @aws-crypto/example-node
-
 ## [4.2.2](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.1...v4.2.2) (2026-03-05)
 
 **Note:** Version bump only for package @aws-crypto/example-node

--- a/modules/example-node/package.json
+++ b/modules/example-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-crypto/example-node",
-  "version": "5.0.0",
+  "version": "4.2.2",
   "scripts": {
     "prepublishOnly": "npm run build",
     "build": "tsc -b tsconfig.json && tsc -b tsconfig.module.json",

--- a/modules/hkdf-node/CHANGELOG.md
+++ b/modules/hkdf-node/CHANGELOG.md
@@ -3,10 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [5.0.0](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.2...v5.0.0) (2026-04-23)
-
-**Note:** Version bump only for package @aws-crypto/hkdf-node
-
 # [4.0.0](https://github.com/aws/aws-encryption-sdk-javascript/compare/v3.2.2...v4.0.0) (2023-07-17)
 
 **Note:** Version bump only for package @aws-crypto/hkdf-node

--- a/modules/hkdf-node/package.json
+++ b/modules/hkdf-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-crypto/hkdf-node",
-  "version": "5.0.0",
+  "version": "4.0.0",
   "description": "nodejs hkdf crypto primitive",
   "scripts": {
     "prepublishOnly": "npm run build",

--- a/modules/integration-browser/CHANGELOG.md
+++ b/modules/integration-browser/CHANGELOG.md
@@ -3,12 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [5.0.0](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.2...v5.0.0) (2026-04-23)
-
-### Bug Fixes
-
-- mitigate dependency issues — remove deprecated packages ([#1654](https://github.com/aws/aws-encryption-sdk-javascript/issues/1654)) ([d795278](https://github.com/aws/aws-encryption-sdk-javascript/commit/d795278bfc6f9d023545f0b36bef701ba5387081))
-
 ## [4.2.2](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.1...v4.2.2) (2026-03-05)
 
 **Note:** Version bump only for package @aws-crypto/integration-browser

--- a/modules/integration-browser/package.json
+++ b/modules/integration-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-crypto/integration-browser",
-  "version": "5.0.0",
+  "version": "4.2.2",
   "scripts": {
     "build": "tsc -b tsconfig.json",
     "lint": "run-s lint-*",

--- a/modules/integration-node/CHANGELOG.md
+++ b/modules/integration-node/CHANGELOG.md
@@ -3,10 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [5.0.0](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.2...v5.0.0) (2026-04-23)
-
-**Note:** Version bump only for package @aws-crypto/integration-node
-
 ## [4.2.2](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.1...v4.2.2) (2026-03-05)
 
 **Note:** Version bump only for package @aws-crypto/integration-node

--- a/modules/integration-node/package.json
+++ b/modules/integration-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-crypto/integration-node",
-  "version": "5.0.0",
+  "version": "4.2.2",
   "scripts": {
     "prepublishOnly": "npm run generate-version.ts; npm run build",
     "generate-version.ts": "npx genversion --es6  src/version.ts",

--- a/modules/integration-vectors/CHANGELOG.md
+++ b/modules/integration-vectors/CHANGELOG.md
@@ -3,10 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [5.0.0](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.2...v5.0.0) (2026-04-23)
-
-**Note:** Version bump only for package @aws-crypto/integration-vectors
-
 ## [4.2.2](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.1...v4.2.2) (2026-03-05)
 
 **Note:** Version bump only for package @aws-crypto/integration-vectors

--- a/modules/integration-vectors/package.json
+++ b/modules/integration-vectors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-crypto/integration-vectors",
-  "version": "5.0.0",
+  "version": "4.2.2",
   "scripts": {
     "build": "tsc -b tsconfig.json",
     "lint": "run-s lint-*",

--- a/modules/kdf-ctr-mode-node/CHANGELOG.md
+++ b/modules/kdf-ctr-mode-node/CHANGELOG.md
@@ -3,10 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [5.0.0](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.2...v5.0.0) (2026-04-23)
-
-**Note:** Version bump only for package @aws-crypto/kdf-ctr-mode-node
-
 # [4.1.0](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.0.2...v4.1.0) (2025-01-16)
 
 ### Features

--- a/modules/kdf-ctr-mode-node/package.json
+++ b/modules/kdf-ctr-mode-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-crypto/kdf-ctr-mode-node",
-  "version": "5.0.0",
+  "version": "4.1.0",
   "description": "nodejs kdf ctr mode crypto primitive",
   "scripts": {
     "prepublishOnly": "npm run build",

--- a/modules/kms-keyring-browser/CHANGELOG.md
+++ b/modules/kms-keyring-browser/CHANGELOG.md
@@ -3,12 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [5.0.0](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.2...v5.0.0) (2026-04-23)
-
-### Bug Fixes
-
-- mitigate dependency issues — remove deprecated packages ([#1654](https://github.com/aws/aws-encryption-sdk-javascript/issues/1654)) ([d795278](https://github.com/aws/aws-encryption-sdk-javascript/commit/d795278bfc6f9d023545f0b36bef701ba5387081))
-
 ## [4.2.2](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.1...v4.2.2) (2026-03-05)
 
 **Note:** Version bump only for package @aws-crypto/kms-keyring-browser

--- a/modules/kms-keyring-browser/package.json
+++ b/modules/kms-keyring-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-crypto/kms-keyring-browser",
-  "version": "5.0.0",
+  "version": "4.2.2",
   "scripts": {
     "prepublishOnly": "npm run generate-version.ts; npm run build",
     "generate-version.ts": "npx genversion --es6  src/version.ts",

--- a/modules/kms-keyring-node/CHANGELOG.md
+++ b/modules/kms-keyring-node/CHANGELOG.md
@@ -3,12 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [5.0.0](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.2...v5.0.0) (2026-04-23)
-
-### Bug Fixes
-
-- mitigate dependency issues — remove deprecated packages ([#1654](https://github.com/aws/aws-encryption-sdk-javascript/issues/1654)) ([d795278](https://github.com/aws/aws-encryption-sdk-javascript/commit/d795278bfc6f9d023545f0b36bef701ba5387081))
-
 ## [4.2.2](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.1...v4.2.2) (2026-03-05)
 
 **Note:** Version bump only for package @aws-crypto/kms-keyring-node

--- a/modules/kms-keyring-node/package.json
+++ b/modules/kms-keyring-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-crypto/kms-keyring-node",
-  "version": "5.0.0",
+  "version": "4.2.2",
   "scripts": {
     "prepublishOnly": "npm run generate-version.ts; npm run build",
     "generate-version.ts": "npx genversion --es6  src/version.ts",

--- a/modules/kms-keyring/CHANGELOG.md
+++ b/modules/kms-keyring/CHANGELOG.md
@@ -3,10 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [5.0.0](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.2...v5.0.0) (2026-04-23)
-
-**Note:** Version bump only for package @aws-crypto/kms-keyring
-
 ## [4.2.2](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.1...v4.2.2) (2026-03-05)
 
 **Note:** Version bump only for package @aws-crypto/kms-keyring

--- a/modules/kms-keyring/package.json
+++ b/modules/kms-keyring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-crypto/kms-keyring",
-  "version": "5.0.0",
+  "version": "4.2.2",
   "scripts": {
     "prepublishOnly": "npm run build",
     "build": "tsc -b tsconfig.json && tsc -b tsconfig.module.json",

--- a/modules/material-management-browser/CHANGELOG.md
+++ b/modules/material-management-browser/CHANGELOG.md
@@ -3,12 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [5.0.0](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.2...v5.0.0) (2026-04-23)
-
-### Bug Fixes
-
-- mitigate dependency issues — remove deprecated packages ([#1654](https://github.com/aws/aws-encryption-sdk-javascript/issues/1654)) ([d795278](https://github.com/aws/aws-encryption-sdk-javascript/commit/d795278bfc6f9d023545f0b36bef701ba5387081))
-
 ## [4.2.2](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.1...v4.2.2) (2026-03-05)
 
 **Note:** Version bump only for package @aws-crypto/material-management-browser

--- a/modules/material-management-browser/package.json
+++ b/modules/material-management-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-crypto/material-management-browser",
-  "version": "5.0.0",
+  "version": "4.2.2",
   "scripts": {
     "prepublishOnly": "npm run build",
     "build": "tsc -b tsconfig.json && tsc -b tsconfig.module.json",
@@ -21,6 +21,7 @@
     "@aws-crypto/material-management": "file:../material-management",
     "@aws-crypto/serialize": "file:../serialize",
     "@aws-crypto/web-crypto-backend": "file:../web-crypto-backend",
+    "@aws-sdk/util-base64": "^3.374.0",
     "@aws-sdk/util-base64": "^3.374.0",
     "tslib": "^2.2.0"
   },

--- a/modules/material-management-node/CHANGELOG.md
+++ b/modules/material-management-node/CHANGELOG.md
@@ -3,10 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [5.0.0](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.2...v5.0.0) (2026-04-23)
-
-**Note:** Version bump only for package @aws-crypto/material-management-node
-
 ## [4.2.2](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.1...v4.2.2) (2026-03-05)
 
 **Note:** Version bump only for package @aws-crypto/material-management-node

--- a/modules/material-management-node/package.json
+++ b/modules/material-management-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-crypto/material-management-node",
-  "version": "5.0.0",
+  "version": "4.2.2",
   "scripts": {
     "prepublishOnly": "npm run build",
     "build": "tsc -b tsconfig.json && tsc -b tsconfig.module.json",

--- a/modules/material-management/CHANGELOG.md
+++ b/modules/material-management/CHANGELOG.md
@@ -3,12 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [5.0.0](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.2...v5.0.0) (2026-04-23)
-
-### Bug Fixes
-
-- mitigate dependency issues — remove deprecated packages ([#1654](https://github.com/aws/aws-encryption-sdk-javascript/issues/1654)) ([d795278](https://github.com/aws/aws-encryption-sdk-javascript/commit/d795278bfc6f9d023545f0b36bef701ba5387081))
-
 ## [4.2.2](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.1...v4.2.2) (2026-03-05)
 
 ### Bug Fixes

--- a/modules/material-management/package.json
+++ b/modules/material-management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-crypto/material-management",
-  "version": "5.0.0",
+  "version": "4.2.2",
   "scripts": {
     "prepublishOnly": "npm run build",
     "build": "tsc -b tsconfig.json && tsc -b tsconfig.module.json",

--- a/modules/raw-aes-keyring-browser/CHANGELOG.md
+++ b/modules/raw-aes-keyring-browser/CHANGELOG.md
@@ -3,12 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [5.0.0](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.2...v5.0.0) (2026-04-23)
-
-### Bug Fixes
-
-- mitigate dependency issues — remove deprecated packages ([#1654](https://github.com/aws/aws-encryption-sdk-javascript/issues/1654)) ([d795278](https://github.com/aws/aws-encryption-sdk-javascript/commit/d795278bfc6f9d023545f0b36bef701ba5387081))
-
 ## [4.2.2](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.1...v4.2.2) (2026-03-05)
 
 **Note:** Version bump only for package @aws-crypto/raw-aes-keyring-browser

--- a/modules/raw-aes-keyring-browser/package.json
+++ b/modules/raw-aes-keyring-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-crypto/raw-aes-keyring-browser",
-  "version": "5.0.0",
+  "version": "4.2.2",
   "scripts": {
     "prepublishOnly": "npm run build",
     "build": "tsc -b tsconfig.json && tsc -b tsconfig.module.json",

--- a/modules/raw-aes-keyring-node/CHANGELOG.md
+++ b/modules/raw-aes-keyring-node/CHANGELOG.md
@@ -3,10 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [5.0.0](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.2...v5.0.0) (2026-04-23)
-
-**Note:** Version bump only for package @aws-crypto/raw-aes-keyring-node
-
 ## [4.2.2](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.1...v4.2.2) (2026-03-05)
 
 **Note:** Version bump only for package @aws-crypto/raw-aes-keyring-node

--- a/modules/raw-aes-keyring-node/package.json
+++ b/modules/raw-aes-keyring-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-crypto/raw-aes-keyring-node",
-  "version": "5.0.0",
+  "version": "4.2.2",
   "scripts": {
     "prepublishOnly": "npm run build",
     "build": "tsc -b tsconfig.json && tsc -b tsconfig.module.json",

--- a/modules/raw-keyring/CHANGELOG.md
+++ b/modules/raw-keyring/CHANGELOG.md
@@ -3,10 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [5.0.0](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.2...v5.0.0) (2026-04-23)
-
-**Note:** Version bump only for package @aws-crypto/raw-keyring
-
 ## [4.2.2](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.1...v4.2.2) (2026-03-05)
 
 **Note:** Version bump only for package @aws-crypto/raw-keyring

--- a/modules/raw-keyring/package.json
+++ b/modules/raw-keyring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-crypto/raw-keyring",
-  "version": "5.0.0",
+  "version": "4.2.2",
   "scripts": {
     "prepublishOnly": "npm run build",
     "build": "tsc -b tsconfig.json && tsc -b tsconfig.module.json",

--- a/modules/raw-rsa-keyring-browser/CHANGELOG.md
+++ b/modules/raw-rsa-keyring-browser/CHANGELOG.md
@@ -3,10 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [5.0.0](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.2...v5.0.0) (2026-04-23)
-
-**Note:** Version bump only for package @aws-crypto/raw-rsa-keyring-browser
-
 ## [4.2.2](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.1...v4.2.2) (2026-03-05)
 
 **Note:** Version bump only for package @aws-crypto/raw-rsa-keyring-browser

--- a/modules/raw-rsa-keyring-browser/package.json
+++ b/modules/raw-rsa-keyring-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-crypto/raw-rsa-keyring-browser",
-  "version": "5.0.0",
+  "version": "4.2.2",
   "scripts": {
     "prepublishOnly": "npm run build",
     "build": "tsc -b tsconfig.json && tsc -b tsconfig.module.json",

--- a/modules/raw-rsa-keyring-node/CHANGELOG.md
+++ b/modules/raw-rsa-keyring-node/CHANGELOG.md
@@ -3,10 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [5.0.0](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.2...v5.0.0) (2026-04-23)
-
-**Note:** Version bump only for package @aws-crypto/raw-rsa-keyring-node
-
 ## [4.2.2](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.1...v4.2.2) (2026-03-05)
 
 **Note:** Version bump only for package @aws-crypto/raw-rsa-keyring-node

--- a/modules/raw-rsa-keyring-node/package.json
+++ b/modules/raw-rsa-keyring-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-crypto/raw-rsa-keyring-node",
-  "version": "5.0.0",
+  "version": "4.2.2",
   "scripts": {
     "prepublishOnly": "npm run build",
     "build": "tsc -b tsconfig.json && tsc -b tsconfig.module.json",

--- a/modules/serialize/CHANGELOG.md
+++ b/modules/serialize/CHANGELOG.md
@@ -3,12 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [5.0.0](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.2...v5.0.0) (2026-04-23)
-
-### Bug Fixes
-
-- mitigate dependency issues — remove deprecated packages ([#1654](https://github.com/aws/aws-encryption-sdk-javascript/issues/1654)) ([d795278](https://github.com/aws/aws-encryption-sdk-javascript/commit/d795278bfc6f9d023545f0b36bef701ba5387081))
-
 ## [4.2.2](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.1...v4.2.2) (2026-03-05)
 
 ### Bug Fixes

--- a/modules/serialize/package.json
+++ b/modules/serialize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-crypto/serialize",
-  "version": "5.0.0",
+  "version": "4.2.2",
   "scripts": {
     "prepublishOnly": "tsc -p tsconfig.json && tsc -p tsconfig.module.json",
     "lint": "run-s lint-*",

--- a/modules/web-crypto-backend/CHANGELOG.md
+++ b/modules/web-crypto-backend/CHANGELOG.md
@@ -3,20 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [5.0.0](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.2.2...v5.0.0) (2026-04-23)
-
-### Bug Fixes
-
-- mitigate dependency issues — remove deprecated packages ([#1654](https://github.com/aws/aws-encryption-sdk-javascript/issues/1654)) ([d795278](https://github.com/aws/aws-encryption-sdk-javascript/commit/d795278bfc6f9d023545f0b36bef701ba5387081))
-
-- feat!: Drop IE11 support (#1651) ([f11b277](https://github.com/aws/aws-encryption-sdk-javascript/commit/f11b277b802180e89532ff83bced7440e42247e0)), closes [#1651](https://github.com/aws/aws-encryption-sdk-javascript/issues/1651)
-
-### BREAKING CHANGES
-
-- The AWS Encryption SDK for JavaScript no longer supports Internet Explorer 11 (IE11). The msCrypto shim and related IE11 detection code have been removed from the web-crypto-backend module.
-
-Co-authored-by: Lucas McDonald <lucmcdon@amazon.com>
-
 ## [4.0.1](https://github.com/aws/aws-encryption-sdk-javascript/compare/v4.0.0...v4.0.1) (2024-07-30)
 
 **Note:** Version bump only for package @aws-crypto/web-crypto-backend

--- a/modules/web-crypto-backend/package.json
+++ b/modules/web-crypto-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-crypto/web-crypto-backend",
-  "version": "5.0.0",
+  "version": "4.0.1",
   "scripts": {
     "prepublishOnly": "npm run build",
     "build": "tsc -b tsconfig.json && tsc -b tsconfig.module.json",

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,7 +92,7 @@
     },
     "modules/branch-keystore-node": {
       "name": "@aws-crypto/branch-keystore-node",
-      "version": "5.0.0",
+      "version": "4.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/kms-keyring": "file:../kms-keyring",
@@ -105,7 +105,7 @@
     },
     "modules/cache-material": {
       "name": "@aws-crypto/cache-material",
-      "version": "5.0.0",
+      "version": "4.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/material-management": "file:../material-management",
@@ -131,7 +131,7 @@
     },
     "modules/caching-materials-manager-browser": {
       "name": "@aws-crypto/caching-materials-manager-browser",
-      "version": "5.0.0",
+      "version": "4.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/cache-material": "file:../cache-material",
@@ -145,7 +145,7 @@
     },
     "modules/caching-materials-manager-node": {
       "name": "@aws-crypto/caching-materials-manager-node",
-      "version": "5.0.0",
+      "version": "4.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/cache-material": "file:../cache-material",
@@ -155,7 +155,7 @@
     },
     "modules/client-browser": {
       "name": "@aws-crypto/client-browser",
-      "version": "5.0.0",
+      "version": "4.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/caching-materials-manager-browser": "file:../caching-materials-manager-browser",
@@ -171,7 +171,7 @@
     },
     "modules/client-node": {
       "name": "@aws-crypto/client-node",
-      "version": "5.0.0",
+      "version": "4.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/branch-keystore-node": "file:../branch-keystore-node",
@@ -188,7 +188,7 @@
     },
     "modules/decrypt-browser": {
       "name": "@aws-crypto/decrypt-browser",
-      "version": "5.0.0",
+      "version": "4.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/material-management-browser": "file:../material-management-browser",
@@ -199,7 +199,7 @@
     },
     "modules/decrypt-node": {
       "name": "@aws-crypto/decrypt-node",
-      "version": "5.0.0",
+      "version": "4.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/material-management-node": "file:../material-management-node",
@@ -234,7 +234,7 @@
     },
     "modules/encrypt-browser": {
       "name": "@aws-crypto/encrypt-browser",
-      "version": "5.0.0",
+      "version": "4.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/material-management-browser": "file:../material-management-browser",
@@ -246,7 +246,7 @@
     },
     "modules/encrypt-node": {
       "name": "@aws-crypto/encrypt-node",
-      "version": "5.0.0",
+      "version": "4.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/material-management-node": "file:../material-management-node",
@@ -281,7 +281,7 @@
     },
     "modules/example-browser": {
       "name": "@aws-crypto/example-browser",
-      "version": "5.0.0",
+      "version": "4.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/client-browser": "file:../client-browser",
@@ -365,7 +365,7 @@
     },
     "modules/example-node": {
       "name": "@aws-crypto/example-node",
-      "version": "5.0.0",
+      "version": "4.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/client-node": "file:../client-node",
@@ -374,7 +374,7 @@
     },
     "modules/hkdf-node": {
       "name": "@aws-crypto/hkdf-node",
-      "version": "5.0.0",
+      "version": "4.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.2.0"
@@ -382,7 +382,7 @@
     },
     "modules/integration-browser": {
       "name": "@aws-crypto/integration-browser",
-      "version": "5.0.0",
+      "version": "4.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/client-browser": "file:../client-browser",
@@ -439,7 +439,7 @@
     },
     "modules/integration-node": {
       "name": "@aws-crypto/integration-node",
-      "version": "5.0.0",
+      "version": "4.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/client-node": "file:../client-node",
@@ -482,7 +482,7 @@
     },
     "modules/integration-vectors": {
       "name": "@aws-crypto/integration-vectors",
-      "version": "5.0.0",
+      "version": "4.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/material-management": "file:../material-management",
@@ -495,7 +495,7 @@
     },
     "modules/kdf-ctr-mode-node": {
       "name": "@aws-crypto/kdf-ctr-mode-node",
-      "version": "5.0.0",
+      "version": "4.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.2.0"
@@ -506,7 +506,7 @@
     },
     "modules/kms-keyring": {
       "name": "@aws-crypto/kms-keyring",
-      "version": "5.0.0",
+      "version": "4.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/material-management": "file:../material-management",
@@ -515,7 +515,7 @@
     },
     "modules/kms-keyring-browser": {
       "name": "@aws-crypto/kms-keyring-browser",
-      "version": "5.0.0",
+      "version": "4.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/kms-keyring": "file:../kms-keyring",
@@ -527,7 +527,7 @@
     },
     "modules/kms-keyring-node": {
       "name": "@aws-crypto/kms-keyring-node",
-      "version": "5.0.0",
+      "version": "4.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/branch-keystore-node": "file:../branch-keystore-node",
@@ -543,7 +543,7 @@
     },
     "modules/material-management": {
       "name": "@aws-crypto/material-management",
-      "version": "5.0.0",
+      "version": "4.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "asn1.js": "^5.3.0",
@@ -557,7 +557,7 @@
     },
     "modules/material-management-browser": {
       "name": "@aws-crypto/material-management-browser",
-      "version": "5.0.0",
+      "version": "4.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/material-management": "file:../material-management",
@@ -569,7 +569,7 @@
     },
     "modules/material-management-node": {
       "name": "@aws-crypto/material-management-node",
-      "version": "5.0.0",
+      "version": "4.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/hkdf-node": "file:../hkdf-node",
@@ -598,7 +598,7 @@
     },
     "modules/raw-aes-keyring-browser": {
       "name": "@aws-crypto/raw-aes-keyring-browser",
-      "version": "5.0.0",
+      "version": "4.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/material-management-browser": "file:../material-management-browser",
@@ -612,7 +612,7 @@
     },
     "modules/raw-aes-keyring-node": {
       "name": "@aws-crypto/raw-aes-keyring-node",
-      "version": "5.0.0",
+      "version": "4.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/material-management-node": "file:../material-management-node",
@@ -623,7 +623,7 @@
     },
     "modules/raw-keyring": {
       "name": "@aws-crypto/raw-keyring",
-      "version": "5.0.0",
+      "version": "4.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/material-management": "file:../material-management",
@@ -633,7 +633,7 @@
     },
     "modules/raw-rsa-keyring-browser": {
       "name": "@aws-crypto/raw-rsa-keyring-browser",
-      "version": "5.0.0",
+      "version": "4.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/material-management-browser": "file:../material-management-browser",
@@ -646,7 +646,7 @@
     },
     "modules/raw-rsa-keyring-node": {
       "name": "@aws-crypto/raw-rsa-keyring-node",
-      "version": "5.0.0",
+      "version": "4.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/material-management-node": "file:../material-management-node",
@@ -656,7 +656,7 @@
     },
     "modules/serialize": {
       "name": "@aws-crypto/serialize",
-      "version": "5.0.0",
+      "version": "4.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/material-management": "file:../material-management",
@@ -688,7 +688,7 @@
     },
     "modules/web-crypto-backend": {
       "name": "@aws-crypto/web-crypto-backend",
-      "version": "5.0.0",
+      "version": "4.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/supports-web-crypto": "5.2.0",


### PR DESCRIPTION
*Issue #, if available:* On Node 22,  `npm install -g npm@latest` fails due to a regression detailed in https://github.com/nodejs/node/issues/62425

*Description of changes:*
1. ) Revert v5.0.0 version bump
2. ) Downgrade node to node 21 for release.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

