### PR TITLE
ci: Add daily CI for v4.x maintenance branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,21 @@ permissions:
   contents: read
   id-token: write
 
-on: [pull_request, workflow_call]
+on:
+  pull_request:
+  workflow_call:
+    inputs:
+      branch:
+        description: "Branch to checkout"
+        required: false
+        default: master
+        type: string
 
 jobs:
   shared-ci:
     uses: ./.github/workflows/shared-ci.yml
+    with:
+      branch: ${{ inputs.branch || 'master' }}
   pr-ci-all-required:
     if: always()
     needs:

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -15,7 +15,12 @@ jobs:
   DAILY_CI:
     # Don't run the cron builds on forks
     if: github.event_name != 'schedule' || github.repository_owner == 'aws'
+    strategy:
+      matrix:
+        branch: [master, v4.x]
     uses: ./.github/workflows/ci.yml
+    with:
+      branch: ${{ matrix.branch }}
   notify:
     needs:
       [

--- a/.github/workflows/shared-ci.yml
+++ b/.github/workflows/shared-ci.yml
@@ -3,6 +3,11 @@ name: Shared CI Tests
 on:
   workflow_call:
     inputs:
+      branch:
+        description: "Branch to checkout"
+        required: false
+        default: master
+        type: string
       test-published-packages:
         description: 'Test against published packages instead of checked out code'
         required: false
@@ -34,6 +39,7 @@ jobs:
         # Always need repo for test scripts and configuration, even when testing published packages
         uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.branch }}
           fetch-depth: 0
           submodules: true
 


### PR DESCRIPTION
Add branch matrix strategy to daily CI workflow so it runs against both master and v4.x branches. This ensures the v4.x maintenance branch is tested daily to catch dependency rot and regressions.

- Add branch input to shared-ci.yml and ci.yml reusable workflows
- Use ref parameter in checkout step to support branch selection
- Add [master, v4.x] matrix to daily_ci.yml

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

