### PR TITLE
chore(deps): remove end-of-life uuid dependency

### DIFF
--- a/modules/branch-keystore-node/package.json
+++ b/modules/branch-keystore-node/package.json
@@ -23,8 +23,7 @@
     "@aws-sdk/client-dynamodb": "^3.616.0",
     "@aws-sdk/client-kms": "^3.616.0",
     "@aws-sdk/util-dynamodb": "^3.616.0",
-    "tslib": "^2.2.0",
-    "uuid": "^9.0.0"
+    "tslib": "^2.2.0"
   },
   "sideEffects": false,
   "main": "./build/main/src/index.js",

--- a/modules/branch-keystore-node/src/branch_keystore.ts
+++ b/modules/branch-keystore-node/src/branch_keystore.ts
@@ -10,7 +10,7 @@ import {
   needs,
   readOnlyProperty,
 } from '@aws-crypto/material-management'
-import { v4 } from 'uuid'
+import { randomUUID } from 'crypto'
 import {
   constructBranchKeyMaterials,
   decryptBranchKey,
@@ -204,7 +204,7 @@ export class BranchKeyStoreNode implements IBranchKeyStoreNode {
     //= aws-encryption-sdk-specification/framework/branch-key-store.md#keystore-id
     //# The Identifier for this KeyStore.
     //# If one is not supplied, then a [version 4 UUID](https://www.ietf.org/rfc/rfc4122.txt) MUST be used.
-    readOnlyProperty(this, 'keyStoreId', keyStoreId ? keyStoreId : v4())
+    readOnlyProperty(this, 'keyStoreId', keyStoreId ? keyStoreId : randomUUID())
     /* Postcondition: If unprovided, the keystore id is a generated valid uuidv4 */
 
     //= aws-encryption-sdk-specification/framework/branch-key-store.md#aws-kms-grant-tokens
@@ -436,7 +436,7 @@ export class BranchKeyStoreNode implements IBranchKeyStoreNode {
     //= aws-encryption-sdk-specification/framework/branch-key-store.md#createkey
     //# If no branch key id is provided, then this operation MUST create a
     //# version 4 UUID to be used as the branch key id.
-    const branchKeyIdentifier = input?.branchKeyIdentifier || v4()
+    const branchKeyIdentifier = input?.branchKeyIdentifier || randomUUID()
     const customEncryptionContext = input?.encryptionContext || {}
 
     await createBranchAndBeaconKeys({

--- a/modules/branch-keystore-node/src/key_helpers.ts
+++ b/modules/branch-keystore-node/src/key_helpers.ts
@@ -10,7 +10,7 @@ import {
   DynamoDBClient,
   TransactWriteItemsCommand,
 } from '@aws-sdk/client-dynamodb'
-import { v4 } from 'uuid'
+import { randomUUID } from 'crypto'
 import { needs } from '@aws-crypto/material-management'
 import { KmsKeyConfig } from './kms_config'
 import {
@@ -177,7 +177,7 @@ export async function createBranchAndBeaconKeys(
 
   //= aws-encryption-sdk-specification/framework/branch-key-store.md#branch-key-and-beacon-key-creation
   //# - `version`: a new guid. This guid MUST be version 4 UUID
-  const branchKeyVersion = v4()
+  const branchKeyVersion = randomUUID()
   const timestamp = getCurrentTimestamp()
 
   const kmsKeyArn = getKmsKeyArn(kmsConfiguration)
@@ -346,7 +346,7 @@ export async function versionActiveBranchKey(
 
   //= aws-encryption-sdk-specification/framework/branch-key-store.md#branch-key-and-beacon-key-creation
   //# - `version`: a new guid. This guid MUST be version 4 UUID
-  const branchKeyVersion = v4()
+  const branchKeyVersion = randomUUID()
   const timestamp = getCurrentTimestamp()
 
   //= aws-encryption-sdk-specification/framework/branch-key-store.md#versionkey

--- a/modules/branch-keystore-node/test/branch_keystore.test.ts
+++ b/modules/branch-keystore-node/test/branch_keystore.test.ts
@@ -7,7 +7,7 @@ import {
   isIBranchKeyStoreNode,
 } from '../src/branch_keystore'
 import { DynamoDBKeyStorage } from '../src/dynamodb_key_storage'
-import { validate, v4, version } from 'uuid'
+import { randomUUID } from 'crypto'
 import chaiAsPromised from 'chai-as-promised'
 import {
   KMSClient,
@@ -40,6 +40,13 @@ import {
 } from '../src/constants'
 
 chai.use(chaiAsPromised)
+
+// Matches a canonical RFC 4122 version 4 UUID, replacing the previous
+// `validate(x) && version(x) === 4` check from the `uuid` package.
+const UUIDV4_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+const isUuidV4 = (input: string): boolean => UUIDV4_PATTERN.test(input)
+
 describe('Test Branch keystore', () => {
   it('Test type guard', () => {
     for (const keyStore of [null, undefined, 0, {}, '']) {
@@ -232,9 +239,7 @@ describe('Test Branch keystore', () => {
         keyManagement: { kmsClient },
       })
 
-      expect(
-        validate(keyStore.keyStoreId) && version(keyStore.keyStoreId) === 4
-      ).equals(true)
+      expect(isUuidV4(keyStore.keyStoreId)).equals(true)
       expect(keyStore.kmsConfiguration._config).equals(kmsConfig)
     })
 
@@ -288,7 +293,7 @@ describe('Test Branch keystore', () => {
           keyStoreId: keyStoreId as any,
         })
 
-        expect(validate(id) && version(id) === 4).equals(true)
+        expect(isUuidV4(id)).equals(true)
       }
     })
 
@@ -504,7 +509,7 @@ describe('Test Branch keystore', () => {
         const ddbClient = new DynamoDBClient({
           region: getRegionFromIdentifier(KEY_ARN),
         })
-        const keyStoreId = v4()
+        const keyStoreId = randomUUID()
         const grantTokens = [] as string[]
         const test = new BranchKeyStoreNode({
           storage: { ddbTableName: DDB_TABLE_NAME, ddbClient: ddbClient },
@@ -852,9 +857,8 @@ describe('Test Branch keystore', () => {
       // New version must differ from old
       expect(newVersion).to.not.equal(oldVersion)
 
-      // New version must be a valid UUID
-      expect(validate(newVersion)).to.be.true
-      expect(version(newVersion)).to.equal(4)
+      // New version must be a valid v4 UUID
+      expect(isUuidV4(newVersion)).to.be.true
 
       // Branch key ID unchanged
       expect(after.branchKeyIdentifier).to.equal(BRANCH_KEY_ID_WITH_EC)
@@ -946,8 +950,7 @@ describe('Test Branch keystore', () => {
 
       // Must return a valid v4 UUID
       expect(result.branchKeyIdentifier).to.be.a('string')
-      expect(validate(result.branchKeyIdentifier)).to.be.true
-      expect(version(result.branchKeyIdentifier)).to.equal(4)
+      expect(isUuidV4(result.branchKeyIdentifier)).to.be.true
 
       // Must be retrievable
       const material = await keyStore.getActiveBranchKey(
@@ -967,7 +970,7 @@ describe('Test Branch keystore', () => {
         keyManagement: { kmsClient },
       })
 
-      const customId = v4()
+      const customId = randomUUID()
       const result = await keyStore.createKey({
         branchKeyIdentifier: customId,
         encryptionContext: { department: 'test' },
@@ -1000,7 +1003,7 @@ describe('Test Branch keystore', () => {
       // 1. Create a new branch key with custom encryption context
       const customEc = { department: 'engineering', project: 'lifecycle' }
       const { branchKeyIdentifier } = await keyStore.createKey({
-        branchKeyIdentifier: v4(),
+        branchKeyIdentifier: randomUUID(),
         encryptionContext: customEc,
       })
 

--- a/modules/cache-material/test/get_local_cryptographic_materials_cache.test.ts
+++ b/modules/cache-material/test/get_local_cryptographic_materials_cache.test.ts
@@ -12,7 +12,7 @@ import {
   AlgorithmSuiteIdentifier,
   NodeBranchKeyMaterial,
 } from '@aws-crypto/material-management'
-import { v4 } from 'uuid'
+import { randomUUID } from 'crypto'
 
 const nodeSuite = new NodeAlgorithmSuite(
   AlgorithmSuiteIdentifier.ALG_AES128_GCM_IV12_TAG16_HKDF_SHA256
@@ -22,7 +22,7 @@ const decryptionMaterial = new NodeDecryptionMaterial(nodeSuite, {})
 const branchKeyMaterial = new NodeBranchKeyMaterial(
   Buffer.alloc(32),
   'id',
-  v4(),
+  randomUUID(),
   {}
 )
 

--- a/modules/integration-node/src/integration_tests.ts
+++ b/modules/integration-node/src/integration_tests.ts
@@ -30,7 +30,7 @@ import got from 'got'
 import streamToPromise from 'stream-to-promise'
 import { ZipFile } from 'yazl'
 import { createWriteStream } from 'fs'
-import { v4 } from 'uuid'
+import { randomUUID } from 'crypto'
 import * as stream from 'stream'
 import * as util from 'util'
 import {
@@ -275,7 +275,7 @@ function decryptionManifestEncryptResults(
     encryptResult: Buffer,
     info: EncryptTestVectorInfo
   ): Promise<boolean> {
-    const testName = v4()
+    const testName = randomUUID()
 
     manifestZip.addBuffer(
       encryptResult,

--- a/modules/kms-keyring-node/test/kms_hkeyring_node.edk-order.test.ts
+++ b/modules/kms-keyring-node/test/kms_hkeyring_node.edk-order.test.ts
@@ -13,7 +13,7 @@ import {
   TEST_ESDK_ALG_SUITE,
   TTL,
 } from './fixtures'
-import { v4 } from 'uuid'
+import { randomUUID } from 'crypto'
 import { uuidv4ToCompressedBytes } from '../src/kms_hkeyring_node_helpers'
 import {
   EncryptedDataKey,
@@ -57,7 +57,7 @@ const badUuidEdkCiphertext = new Uint8Array(Buffer.alloc(ciphertextLength))
 
 // an edk whose branch key version can be decompressed but is non-existent in
 // the keystore
-const nonExistentBranchKeyVersion = v4()
+const nonExistentBranchKeyVersion = randomUUID()
 const nonExistentBranchKeyVersionEdkCiphertext = new Uint8Array(
   badUuidEdkCiphertext
 )

--- a/modules/kms-keyring-node/test/kms_hkeyring_node.helpers.test.ts
+++ b/modules/kms-keyring-node/test/kms_hkeyring_node.helpers.test.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { randomBytes } from 'crypto'
+import { randomBytes, randomUUID } from 'crypto'
 import {
   wrapAad,
   destructureCiphertext,
@@ -17,7 +17,6 @@ import {
   NodeEncryptionMaterial,
 } from '@aws-crypto/material-management'
 import { serializeFactory, SerializeOptions } from '@aws-crypto/serialize'
-import { v4 } from 'uuid'
 
 describe('KmsHierarchicalKeyRingNode: helpers', () => {
   //= aws-encryption-sdk-specification/framework/aws-kms/aws-kms-hierarchical-keyring.md#ciphertext
@@ -198,7 +197,7 @@ describe('KmsHierarchicalKeyRingNode: helpers', () => {
         const expectedPdk = randomBytes(algSuite.keyLengthBytes)
         const branchKey = Buffer.alloc(32)
         const branchKeyId = 'myBranchKey'
-        const branchKeyVersion = v4()
+        const branchKeyVersion = randomUUID()
         const encryptionContext = { key: 'value' }
         const branchKeyMaterial = new NodeBranchKeyMaterial(
           branchKey,
@@ -260,7 +259,7 @@ describe('KmsHierarchicalKeyRingNode: helpers', () => {
         )
         const branchKey = Buffer.alloc(32)
         const branchKeyId = 'myBranchKey'
-        const branchKeyVersion = v4()
+        const branchKeyVersion = randomUUID()
         const encryptionContext = { key: 'value' }
         const branchKeyMaterial = new NodeBranchKeyMaterial(
           branchKey,

--- a/modules/material-management/package.json
+++ b/modules/material-management/package.json
@@ -20,11 +20,7 @@
   "dependencies": {
     "asn1.js": "^5.3.0",
     "bn.js": "^5.2.3",
-    "tslib": "^2.2.0",
-    "uuid": "^10.0.0"
-  },
-  "devDependencies": {
-    "@types/uuid": "^10.0.0"
+    "tslib": "^2.2.0"
   },
   "sideEffects": false,
   "main": "./build/main/src/index.js",

--- a/modules/material-management/src/cryptographic_material.ts
+++ b/modules/material-management/src/cryptographic_material.ts
@@ -17,7 +17,14 @@ import { KeyringTrace, KeyringTraceFlag } from './keyring_trace'
 import { NodeAlgorithmSuite } from './node_algorithms'
 import { WebCryptoAlgorithmSuite } from './web_crypto_algorithms'
 import { needs } from './needs'
-import { validate, version } from 'uuid'
+
+/* Matches a canonical RFC 4122 version 4 UUID.
+ * Equivalent to the previous `validate(x) && version(x) === 4` check
+ * from the `uuid` package: the third group must start with `4` (version)
+ * and the fourth group must start with `8`, `9`, `a`, or `b` (variant).
+ */
+const UUIDV4_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
 /* KeyObject were introduced in v11.
  * They protect the data key better than a Buffer.
@@ -180,7 +187,7 @@ export class NodeBranchKeyMaterial implements BranchKeyMaterial {
 
     /* Precondition: branch key version must be valid version 4 uuid */
     needs(
-      validate(branchKeyVersion) && version(branchKeyVersion) === 4,
+      UUIDV4_PATTERN.test(branchKeyVersion),
       'Branch key version must be valid version 4 uuid'
     )
 

--- a/modules/material-management/test/cryptographic_material.test.ts
+++ b/modules/material-management/test/cryptographic_material.test.ts
@@ -31,8 +31,13 @@ import {
   supportsKeyObject,
   NodeBranchKeyMaterial,
 } from '../src/cryptographic_material'
-import { v1, v4, v3, v5 } from 'uuid'
-import { createSecretKey } from 'crypto'
+import { createSecretKey, randomUUID } from 'crypto'
+
+// Valid-format UUIDs whose version nibble is not 4, used to exercise the
+// "not a v4 UUID" rejection paths (previously generated via uuid's v1/v3/v5).
+const uuidV1 = '2c5ea4c0-4067-11e9-8bad-9b1deb4d3b7d'
+const uuidV3 = '9125a8dc-52ee-365b-a5aa-81b0b3681cf6'
+const uuidV5 = '74738ff5-5367-5958-9aee-98fffdcd1876'
 
 describe('decorateCryptographicMaterial', () => {
   it('will decorate', () => {
@@ -994,7 +999,7 @@ describe('decorateWebCryptoMaterial:Helpers', () => {
 describe('NodeBranchKeyMaterial', () => {
   const branchKey = Buffer.alloc(32)
   const branchKeyId = 'id'
-  const branchKeyVersion = v4()
+  const branchKeyVersion = randomUUID()
   const encryptionContext = {}
   const test = new NodeBranchKeyMaterial(
     branchKey,
@@ -1094,19 +1099,17 @@ describe('NodeBranchKeyMaterial', () => {
         new NodeBranchKeyMaterial(
           branchKey,
           branchKeyId,
-          v1(),
+          uuidV1,
           encryptionContext
         )
     ).to.throw('Branch key version must be valid version 4 uuid')
 
-    const namespace = v4()
-    const name = 'example.com'
     expect(
       () =>
         new NodeBranchKeyMaterial(
           branchKey,
           branchKeyId,
-          v3(name, namespace),
+          uuidV3,
           encryptionContext
         )
     ).to.throw('Branch key version must be valid version 4 uuid')
@@ -1115,7 +1118,7 @@ describe('NodeBranchKeyMaterial', () => {
         new NodeBranchKeyMaterial(
           branchKey,
           branchKeyId,
-          v5(name, namespace),
+          uuidV5,
           encryptionContext
         )
     ).to.throw('Branch key version must be valid version 4 uuid')
@@ -1124,7 +1127,7 @@ describe('NodeBranchKeyMaterial', () => {
       new NodeBranchKeyMaterial(
         branchKey,
         branchKeyId,
-        v4().toUpperCase(),
+        randomUUID().toUpperCase(),
         encryptionContext
       )
     })

--- a/modules/serialize/package.json
+++ b/modules/serialize/package.json
@@ -20,11 +20,7 @@
     "@aws-crypto/material-management": "file:../material-management",
     "asn1.js": "^5.3.0",
     "bn.js": "^5.2.3",
-    "tslib": "^2.2.0",
-    "uuid": "^10.0.0"
-  },
-  "devDependencies": {
-    "@types/uuid": "^10.0.0"
+    "tslib": "^2.2.0"
   },
   "sideEffects": false,
   "main": "./build/main/src/index.js",

--- a/modules/serialize/src/uuidv4_factory.ts
+++ b/modules/serialize/src/uuidv4_factory.ts
@@ -2,11 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { needs } from '@aws-crypto/material-management'
-import { validate, version } from 'uuid'
+
+/* Matches a canonical RFC 4122 version 4 UUID.
+ * Equivalent to the previous `validate(x) && version(x) === 4` check
+ * from the `uuid` package: the third group must start with `4` (version)
+ * and the fourth group must start with `8`, `9`, `a`, or `b` (variant).
+ */
+const UUIDV4_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
 // function to validate a string as uuidv4
-const validateUuidv4 = (input: string): boolean =>
-  validate(input) && version(input) === 4
+const validateUuidv4 = (input: string): boolean => UUIDV4_PATTERN.test(input)
 
 // accepts user defined lambda functions to convert between a string and
 // compressed hex encoded

--- a/modules/serialize/test/uuidv4_factory.test.ts
+++ b/modules/serialize/test/uuidv4_factory.test.ts
@@ -3,9 +3,15 @@
 
 // tests contains MPL tests: https://github.com/aws/aws-cryptographic-material-providers-library/blob/da6812fa30315fda75d4277f814d1d0e36e22498/StandardLibrary/test/UUID.dfy
 
-import { v3, v5, v1, v4 } from 'uuid'
+import { randomUUID } from 'crypto'
 import { uuidv4Factory } from '../src/uuidv4_factory'
 import { expect } from 'chai'
+
+// Valid-format UUIDs whose version nibble is not 4, used to exercise the
+// "not a v4 UUID" rejection paths (previously generated via uuid's v1/v3/v5).
+const uuidV1 = '2c5ea4c0-4067-11e9-8bad-9b1deb4d3b7d'
+const uuidV3 = '9125a8dc-52ee-365b-a5aa-81b0b3681cf6'
+const uuidV5 = '74738ff5-5367-5958-9aee-98fffdcd1876'
 
 const stringToHexBytes = (input: string): Uint8Array =>
   new Uint8Array(Buffer.from(input, 'hex'))
@@ -42,7 +48,7 @@ describe('uuidv4Factory', () => {
   })
 
   it('Test generate and conversion', () => {
-    const uuid = v4()
+    const uuid = randomUUID()
     const uuidBytes = uuidv4ToCompressedBytes(uuid)
     const bytesToString = decompressBytesToUuidv4(uuidBytes)
     const stringToBytes = uuidv4ToCompressedBytes(bytesToString)
@@ -82,17 +88,15 @@ describe('uuidv4Factory', () => {
 
   describe('uuidv4ToCompressedBytes', () => {
     it('Precondition: Input string must be valid uuidv4', () => {
-      expect(() => uuidv4ToCompressedBytes(v1())).to.throw(
+      expect(() => uuidv4ToCompressedBytes(uuidV1)).to.throw(
         'Input must be valid uuidv4'
       )
 
-      const name = 'example.com'
-      const namespace = uuidString
-      expect(() => uuidv4ToCompressedBytes(v3(name, namespace))).to.throw(
+      expect(() => uuidv4ToCompressedBytes(uuidV3)).to.throw(
         'Input must be valid uuidv4'
       )
 
-      expect(() => uuidv4ToCompressedBytes(v5(name, namespace))).to.throw(
+      expect(() => uuidv4ToCompressedBytes(uuidV5)).to.throw(
         'Input must be valid uuidv4'
       )
     })

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,8 +99,7 @@
         "@aws-sdk/client-dynamodb": "^3.616.0",
         "@aws-sdk/client-kms": "^3.616.0",
         "@aws-sdk/util-dynamodb": "^3.616.0",
-        "tslib": "^2.2.0",
-        "uuid": "^9.0.0"
+        "tslib": "^2.2.0"
       }
     },
     "modules/cache-material": {
@@ -548,11 +547,7 @@
       "dependencies": {
         "asn1.js": "^5.3.0",
         "bn.js": "^5.2.3",
-        "tslib": "^2.2.0",
-        "uuid": "^10.0.0"
-      },
-      "devDependencies": {
-        "@types/uuid": "^10.0.0"
+        "tslib": "^2.2.0"
       }
     },
     "modules/material-management-browser": {
@@ -582,19 +577,6 @@
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
       "integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w=="
-    },
-    "modules/material-management/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "modules/raw-aes-keyring-browser": {
       "name": "@aws-crypto/raw-aes-keyring-browser",
@@ -662,29 +644,13 @@
         "@aws-crypto/material-management": "file:../material-management",
         "asn1.js": "^5.3.0",
         "bn.js": "^5.2.3",
-        "tslib": "^2.2.0",
-        "uuid": "^10.0.0"
-      },
-      "devDependencies": {
-        "@types/uuid": "^10.0.0"
+        "tslib": "^2.2.0"
       }
     },
     "modules/serialize/node_modules/bn.js": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
       "integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w=="
-    },
-    "modules/serialize/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "modules/web-crypto-backend": {
       "name": "@aws-crypto/web-crypto-backend",
@@ -5054,12 +5020,6 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "license": "MIT"
-    },
-    "node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-      "dev": true
     },
     "node_modules/@types/yargs": {
       "version": "17.0.32",
@@ -13367,18 +13327,6 @@
         }
       }
     },
-    "node_modules/lerna/node_modules/@types/node": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
-      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~7.18.0"
-      }
-    },
     "node_modules/lerna/node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -20273,15 +20221,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/unique-filename": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-5.0.0.tgz",
@@ -20411,19 +20350,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache": {


### PR DESCRIPTION
Replace the `uuid` package with native APIs to resolve its end-of-life status (issue #1666):
- validation via a canonical RFC 4122 v4 regex (material-management, serialize)
- generation via crypto.randomUUID() (branch-keystore-node, integration-node)

The SDK only used validate/version and v4(), and was never exposed to GHSA-w5hq-g745-h8pq (v3/v5/v6 buffer paths). Removing the dependency also avoids uuid v11+'s TS5.0-only type declarations, which are incompatible with the repo's pinned typescript@^4.

Fixes #1666

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

