### PR TITLE
fix(ci): pass branch input into shared-ci for release workflow

### DIFF
--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -26,6 +26,8 @@ env:
 jobs:
   pre-release-ci:
     uses: ./.github/workflows/shared-ci.yml
+    with:
+      branch: ${{ github.event.inputs.branch }}
 
   # Once all tests have passed, run semantic versioning
   version:
@@ -119,3 +121,4 @@ jobs:
     needs: [publish]
     with:
       test-published-packages: true
+      branch: ${{ github.event.inputs.branch }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The release workflow wasn't running pre/post-release testing from the `branch` input, now it is

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

