### PR TITLE
fix(ci): release from the dispatched branch instead of a branch input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,21 +4,11 @@ permissions:
   contents: read
   id-token: write
 
-on:
-  pull_request:
-  workflow_call:
-    inputs:
-      branch:
-        description: "Ref to check out. Empty (the default) uses the ref that triggered the run."
-        required: false
-        default: ''
-        type: string
+on: [pull_request, workflow_call]
 
 jobs:
   shared-ci:
     uses: ./.github/workflows/shared-ci.yml
-    with:
-      branch: ${{ inputs.branch }}
   pr-ci-all-required:
     if: always()
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,16 +9,16 @@ on:
   workflow_call:
     inputs:
       branch:
-        description: "Branch to checkout"
+        description: "Ref to check out. Empty (the default) uses the ref that triggered the run."
         required: false
-        default: master
+        default: ''
         type: string
 
 jobs:
   shared-ci:
     uses: ./.github/workflows/shared-ci.yml
     with:
-      branch: ${{ inputs.branch || 'master' }}
+      branch: ${{ inputs.branch }}
   pr-ci-all-required:
     if: always()
     needs:

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -29,6 +29,12 @@ jobs:
     needs: [pre-release-ci]
     environment: release
     steps:
+      - name: Require a branch
+        if: github.ref_type != 'branch'
+        run: |
+          echo "::error::Dispatch this workflow from a branch (got ${{ github.ref_type }} '${{ github.ref_name }}'). To release a specific commit, point a branch at it first."
+          exit 1
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -69,9 +69,6 @@ jobs:
           gh auth setup-git
 
       - name: Configure git
-        # Release the branch the workflow was dispatched from. The reusable
-        # shared-ci workflow's test matrix is read from this same ref, so the
-        # branch being released must be the ref the workflow runs on.
         env:
           BRANCH: ${{ github.ref_name }}
         run: |
@@ -93,8 +90,7 @@ jobs:
     needs: [pre-release-ci, version]
     environment: release
     steps:
-      # Check out by branch name (not the triggering SHA) so we pick up the
-      # version-bump commit the `version` job just pushed to this branch.
+      # Include the version-bump commit the version job pushed
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.ref_name }}

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -14,10 +14,6 @@ on:
         description: 'NPM distribution tag'
         required: false
         default: 'latest'
-      branch:
-        description: 'The branch to release from'
-        required: false
-        default: 'master'
 
 env:
   NODE_OPTIONS: "--max-old-space-size=4096"
@@ -73,8 +69,11 @@ jobs:
           gh auth setup-git
 
       - name: Configure git
+        # Release the branch the workflow was dispatched from. The reusable
+        # shared-ci workflow's test matrix is read from this same ref, so the
+        # branch being released must be the ref the workflow runs on.
         env:
-          BRANCH: ${{ github.event.inputs.branch }}
+          BRANCH: ${{ github.ref_name }}
         run: |
           git config --global user.name "aws-crypto-tools-ci-bot"
           git config --global user.email "no-reply@noemail.local"
@@ -94,9 +93,11 @@ jobs:
     needs: [pre-release-ci, version]
     environment: release
     steps:
+      # Check out by branch name (not the triggering SHA) so we pick up the
+      # version-bump commit the `version` job just pushed to this branch.
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.branch }}
+          ref: ${{ github.ref_name }}
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -74,7 +74,7 @@ jobs:
         run: |
           git config --global user.name "aws-crypto-tools-ci-bot"
           git config --global user.email "no-reply@noemail.local"
-          git checkout $BRANCH
+          git checkout "$BRANCH"
 
       - name: Version packages
         env:

--- a/.github/workflows/shared-ci.yml
+++ b/.github/workflows/shared-ci.yml
@@ -32,9 +32,6 @@ jobs:
     steps:
       - name: Checkout code
         # Always need repo for test scripts and configuration, even when testing published packages
-        # No explicit ref: checkout defaults to the ref that triggered the
-        # run (the PR merge ref for CI, or the dispatched branch for a release),
-        # which keeps the tested code and this workflow's matrix on the same branch.
         uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/.github/workflows/shared-ci.yml
+++ b/.github/workflows/shared-ci.yml
@@ -3,11 +3,6 @@ name: Shared CI Tests
 on:
   workflow_call:
     inputs:
-      branch:
-        description: "Branch to checkout"
-        required: false
-        default: master
-        type: string
       test-published-packages:
         description: 'Test against published packages instead of checked out code'
         required: false
@@ -37,9 +32,11 @@ jobs:
     steps:
       - name: Checkout code
         # Always need repo for test scripts and configuration, even when testing published packages
+        # No explicit ref: checkout defaults to the ref that triggered the
+        # run (the PR merge ref for CI, or the dispatched branch for a release),
+        # which keeps the tested code and this workflow's matrix on the same branch.
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.branch }}
           fetch-depth: 0
           submodules: true
 

--- a/.github/workflows/shared-ci.yml
+++ b/.github/workflows/shared-ci.yml
@@ -3,11 +3,6 @@ name: Shared CI Tests
 on:
   workflow_call:
     inputs:
-      branch:
-        description: 'Ref to check out. Empty (the default) uses the ref that triggered the run.'
-        required: false
-        default: ''
-        type: string
       test-published-packages:
         description: 'Test against published packages instead of checked out code'
         required: false
@@ -39,7 +34,6 @@ jobs:
         # Always need repo for test scripts and configuration, even when testing published packages
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.branch }}
           fetch-depth: 0
           submodules: true
 

--- a/.github/workflows/shared-ci.yml
+++ b/.github/workflows/shared-ci.yml
@@ -3,6 +3,11 @@ name: Shared CI Tests
 on:
   workflow_call:
     inputs:
+      branch:
+        description: 'Ref to check out. Empty (the default) uses the ref that triggered the run.'
+        required: false
+        default: ''
+        type: string
       test-published-packages:
         description: 'Test against published packages instead of checked out code'
         required: false
@@ -34,6 +39,7 @@ jobs:
         # Always need repo for test scripts and configuration, even when testing published packages
         uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.branch }}
           fetch-depth: 0
           submodules: true
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Remove the `branch` input from workflows.

Before, the src/test code from `branch` would be checked out, but NOT the test environments configured on `branch`. This led to a weird case where I was trying to release from `branch=v4.x` from the master branch. ESDK JS 4.x supports node <22 but 5.x doesn't; master doesn't test against <22 since it's a 5.x branch.

Now, release always runs from the branch configured in the release workflow run. (This is also simpler, Kess and I were confused by this distinction earlier)

(Should also note that the "must release from a branch" (versus releasing from a specific commit) requirement was implicit, but is now explicit. In the release workflow the CI bot pushes a changelog commit, which would fail if it checked out a commit rather than a branch.)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.