### PR TITLE
fix(ci): release v4.x from the dispatched branch instead of a branch input

### DIFF
--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -68,9 +68,6 @@ jobs:
           gh auth setup-git
 
       - name: Configure git
-        # Release the branch the workflow was dispatched from. The reusable
-        # shared-ci workflow's test matrix is read from this same ref, so the
-        # branch being released must be the ref the workflow runs on.
         env:
           BRANCH: ${{ github.ref_name }}
           VERSION_BUMP: ${{ github.event.inputs.version_bump }}
@@ -104,8 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [pre-release-ci, version]
     steps:
-      # Check out by branch name (not the triggering SHA) so we pick up the
-      # version-bump commit the `version` job just pushed to this branch.
+      # Include the version-bump commit the version job pushed
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.ref_name }}

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -14,10 +14,6 @@ on:
         description: 'NPM distribution tag'
         required: false
         default: 'latest'
-      branch:
-        description: 'The branch to release from'
-        required: false
-        default: 'master'
 
 env:
   NODE_OPTIONS: "--max-old-space-size=4096"
@@ -72,8 +68,11 @@ jobs:
           gh auth setup-git
 
       - name: Configure git
+        # Release the branch the workflow was dispatched from. The reusable
+        # shared-ci workflow's test matrix is read from this same ref, so the
+        # branch being released must be the ref the workflow runs on.
         env:
-          BRANCH: ${{ github.event.inputs.branch }}
+          BRANCH: ${{ github.ref_name }}
           VERSION_BUMP: ${{ github.event.inputs.version_bump }}
         run: |
           git config --global user.name "aws-crypto-tools-ci-bot"
@@ -105,7 +104,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [pre-release-ci, version]
     steps:
+      # Check out by branch name (not the triggering SHA) so we pick up the
+      # version-bump commit the `version` job just pushed to this branch.
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -28,6 +28,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: [pre-release-ci]
     steps:
+      - name: Require a branch
+        if: github.ref_type != 'branch'
+        run: |
+          echo "::error::Dispatch this workflow from a branch (got ${{ github.ref_type }} '${{ github.ref_name }}'). To release a specific commit, point a branch at it first."
+          exit 1
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Remove the `branch` input from workflows.

Before, the src/test code from `branch` would be checked out, but NOT the test environments configured on `branch`. This led to a weird case where I was trying to release from `branch=v4.x` from the master branch. ESDK JS 4.x supports node <22 but 5.x doesn't; master doesn't test against <22 since it's a 5.x branch.

Now, release always runs from the branch configured in the release workflow run. (This is also simpler, Kess and I were confused by this distinction earlier)

(Should also note that the "must release from a branch" (versus releasing from a specific commit) requirement was implicit, but is now explicit. In the release workflow the CI bot pushes a changelog commit, which would fail if it checked out a commit rather than a branch.)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.