### PR TITLE
fix(release): stop passing removed branch input to shared-ci

### DIFF
--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -22,8 +22,6 @@ env:
 jobs:
   pre-release-ci:
     uses: ./.github/workflows/shared-ci.yml
-    with:
-      branch: ${{ github.event.inputs.branch }}
 
   # Once all tests have passed, run semantic versioning
   version:
@@ -124,4 +122,3 @@ jobs:
     needs: [publish]
     with:
       test-published-packages: true
-      branch: ${{ github.event.inputs.branch }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Remove the `branch` input that doesn't exist anymore

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.