### PR TITLE
fix(release): publish on Node LTS so npm@latest installs

### DIFF
--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -103,7 +103,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: 'latest'
           registry-url: 'https://registry.npmjs.org'
 
       # Ensure npm 11.5.1 or later is installed

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -103,7 +103,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 'latest'
+          node-version: 'lts/*'
           registry-url: 'https://registry.npmjs.org'
 
       # Ensure npm 11.5.1 or later is installed


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Bump the publish job's Node to always publish with `lts/*`.

The latest npm (12.x) requires Node `^22` so 20 fails, but it probably makes sense to always use LTS to publish.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.