### PR TITLE
fix(release): drop --unsafe-perm from publish npm ci

### DIFF
--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -109,7 +109,7 @@ jobs:
       # Ensure npm 11.5.1 or later is installed
       - name: Update npm
         run: npm install -g npm@latest
-      - run: npm ci --unsafe-perm
+      - run: npm ci
       - run: npm run build --if-present
       - run: npx lerna publish from-package --yes --dist-tag "$DIST_TAG"
         env:

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -106,7 +106,6 @@ jobs:
           node-version: 'lts/*'
           registry-url: 'https://registry.npmjs.org'
 
-      # Ensure npm 11.5.1 or later is installed
       - name: Update npm
         run: npm install -g npm@latest
       - run: npm ci


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Drop `--unsafe-perm` from the publish job's `npm ci`. This flag was removed in npm 12, which we just started using.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.