### PR TITLE
fix(release): drop NPM_CONFIG_UNSAFE_PERM env

### DIFF
--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -17,7 +17,6 @@ on:
 
 env:
   NODE_OPTIONS: "--max-old-space-size=4096"
-  NPM_CONFIG_UNSAFE_PERM: true
 
 jobs:
   pre-release-ci:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Remove `NPM_CONFIG_UNSAFE_PERM: true` env.

npm 12 warns on this; it will error on it in a future major.

This mirrors the same removal on master in #1682.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.