### PR TITLE
fix(release): allow publishing with no tag; publish one package at a time

### DIFF
--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -11,9 +11,9 @@ on:
         description: '[Optional] Override semantic versioning with explict version (allowed values: "patch", "minor", "major", or explicit version)'
         default: ''
       dist_tag:
-        description: 'NPM dist-tag. Leave empty to publish without moving the "latest" tag (use for 4.x maintenance releases).'
+        description: 'NPM dist-tag to publish under; delete to publish without an explicit dist-tag'
         required: false
-        default: ''
+        default: 'latest'
 
 env:
   NODE_OPTIONS: "--max-old-space-size=4096"
@@ -109,8 +109,6 @@ jobs:
         run: npm install -g npm@latest
       - run: npm ci
       - run: npm run build --if-present
-      # If no dist-tag is given, omit --dist-tag entirely so npm doesn't move
-      # `latest` (modern npm won't set `latest` when publishing a lower version).
       - name: Publish
         env:
           NPM_CONFIG_PROVENANCE: true

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -11,7 +11,7 @@ on:
         description: '[Optional] Override semantic versioning with explict version (allowed values: "patch", "minor", "major", or explicit version)'
         default: ''
       dist_tag:
-        description: 'NPM dist-tag to publish under; delete to publish without an explicit dist-tag'
+        description: 'NPM dist-tag to publish under; leave empty to publish without an explicit dist-tag'
         required: false
         default: 'latest'
 

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -11,8 +11,9 @@ on:
         description: '[Optional] Override semantic versioning with explict version (allowed values: "patch", "minor", "major", or explicit version)'
         default: ''
       dist_tag:
-        description: 'NPM distribution tag (required; this is a 4.x maintenance line, so do not use "latest")'
-        required: true
+        description: 'NPM dist-tag. Leave empty to publish without moving the "latest" tag (use for 4.x maintenance releases).'
+        required: false
+        default: ''
 
 env:
   NODE_OPTIONS: "--max-old-space-size=4096"
@@ -31,12 +32,6 @@ jobs:
         if: github.ref_type != 'branch'
         run: |
           echo "::error::Dispatch this workflow from a branch (got ${{ github.ref_type }} '${{ github.ref_name }}'). To release a specific commit, point a branch at it first."
-          exit 1
-
-      - name: Require a dist-tag
-        if: github.event.inputs.dist_tag == ''
-        run: |
-          echo "::error::Specify an npm dist-tag. This is the 4.x maintenance line; do not publish to 'latest'."
           exit 1
 
       - name: Checkout code
@@ -114,10 +109,18 @@ jobs:
         run: npm install -g npm@latest
       - run: npm ci
       - run: npm run build --if-present
-      - run: npx lerna publish from-package --yes --dist-tag "$DIST_TAG"
+      # If no dist-tag is given, omit --dist-tag entirely so npm doesn't move
+      # `latest` (modern npm won't set `latest` when publishing a lower version).
+      - name: Publish
         env:
           NPM_CONFIG_PROVENANCE: true
           DIST_TAG: ${{ github.event.inputs.dist_tag }}
+        run: |
+          if [ -n "$DIST_TAG" ]; then
+            npx lerna publish from-package --yes --dist-tag "$DIST_TAG"
+          else
+            npx lerna publish from-package --yes
+          fi
 
   # Once publishing is complete, validate that the published packages are useable
   validate:

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -11,9 +11,8 @@ on:
         description: '[Optional] Override semantic versioning with explict version (allowed values: "patch", "minor", "major", or explicit version)'
         default: ''
       dist_tag:
-        description: 'NPM distribution tag'
-        required: false
-        default: 'latest'
+        description: 'NPM distribution tag (required; this is a 4.x maintenance line, so do not use "latest")'
+        required: true
 
 env:
   NODE_OPTIONS: "--max-old-space-size=4096"
@@ -32,6 +31,12 @@ jobs:
         if: github.ref_type != 'branch'
         run: |
           echo "::error::Dispatch this workflow from a branch (got ${{ github.ref_type }} '${{ github.ref_name }}'). To release a specific commit, point a branch at it first."
+          exit 1
+
+      - name: Require a dist-tag
+        if: github.event.inputs.dist_tag == ''
+        run: |
+          echo "::error::Specify an npm dist-tag. This is the 4.x maintenance line; do not publish to 'latest'."
           exit 1
 
       - name: Checkout code

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -115,9 +115,9 @@ jobs:
           DIST_TAG: ${{ github.event.inputs.dist_tag }}
         run: |
           if [ -n "$DIST_TAG" ]; then
-            npx lerna publish from-package --yes --dist-tag "$DIST_TAG"
+            npx lerna publish from-package --yes --concurrency 1 --dist-tag "$DIST_TAG"
           else
-            npx lerna publish from-package --yes
+            npx lerna publish from-package --yes --concurrency 1
           fi
 
   # Once publishing is complete, validate that the published packages are useable

--- a/package-lock.json
+++ b/package-lock.json
@@ -13785,6 +13785,18 @@
         }
       }
     },
+    "node_modules/lerna/node_modules/@types/node": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
     "node_modules/lerna/node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -20942,6 +20954,15 @@
       "engines": {
         "node": ">=18.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/universal-user-agent": {
       "version": "6.0.1",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1. When `dist_tag` is empty, do not publish a tag. (Current behavior is to pass an empty `dist_tag` to the npm CLI, which the CLI interprets as "set latest tag", which we don't want.)
2. Publish one package at a time. Releasing packages in parallel submits many provenance attestations to Rekor (npm publish signing logbook) at once. Submissions to Rekor can time out and be retried. If the first attempt succeeded, the retry fails, then indicates "failure" to npm, and npm doesn't attempt to publish the package. Setting `--concurrency 1` serializes publishes so only one attestation is in flight at a time, (possibly, hopefully) reducing those timeout-induced 409s.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.