### PR TITLE
fix(release): allow publishing with no tag; publish one package at a time

### DIFF
--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -11,7 +11,7 @@ on:
         description: '[Optional] Override semantic versioning with explict version (allowed values: "patch", "minor", "major", or explicit version)'
         default: ''
       dist_tag:
-        description: 'NPM distribution tag'
+        description: 'NPM dist-tag to publish under; delete to publish without an explicit dist-tag'
         required: false
         default: 'latest'
 
@@ -109,10 +109,16 @@ jobs:
         run: npm install -g npm@latest
       - run: npm ci
       - run: npm run build --if-present
-      - run: npx lerna publish from-package --yes --dist-tag "$DIST_TAG"
+      - name: Publish
         env:
           NPM_CONFIG_PROVENANCE: true
           DIST_TAG: ${{ github.event.inputs.dist_tag }}
+        run: |
+          if [ -n "$DIST_TAG" ]; then
+            npx lerna publish from-package --yes --dist-tag "$DIST_TAG"
+          else
+            npx lerna publish from-package --yes
+          fi
 
   # Once publishing is complete, validate that the published packages are useable
   validate:

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -115,9 +115,9 @@ jobs:
           DIST_TAG: ${{ github.event.inputs.dist_tag }}
         run: |
           if [ -n "$DIST_TAG" ]; then
-            npx lerna publish from-package --yes --dist-tag "$DIST_TAG"
+            npx lerna publish from-package --yes --concurrency 1 --dist-tag "$DIST_TAG"
           else
-            npx lerna publish from-package --yes
+            npx lerna publish from-package --yes --concurrency 1
           fi
 
   # Once publishing is complete, validate that the published packages are useable


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1. When `dist_tag` is empty, do not publish a tag. (Current behavior is to pass an empty `dist_tag` to the npm CLI, which the CLI interprets as "set latest tag", which we don't want.)
2. Publish one package at a time. Releasing packages in parallel submits many provenance attestations to Rekor (npm publish signing logbook) at once. Submissions to Rekor can time out and be retried. If the first attempt succeeded, the retry fails, then indicates "failure" to npm, and npm doesn't attempt to publish the package. Setting `--concurrency 1` serializes publishes so only one attestation is in flight at a time, (possibly, hopefully) reducing those timeout-induced 409s.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.